### PR TITLE
Fix grammar on faq/about.html 

### DIFF
--- a/remo/base/templates/about.html
+++ b/remo/base/templates/about.html
@@ -18,7 +18,7 @@ Mozilla Reps - About
     contributor base grow.</p>
     <p>The Mozilla Reps program provides a simple framework and
     specific tools to help volunteer Mozillians become official
-    representatives of Mozilla in their region. Anyone 18 and older who is
+    representatives of Mozilla in their region. Anyone 18 or older who is
     passionate and knowledgeable about Mozilla and who is ready to
     dive deeper into the project can sign-up to the program. The
     Mozilla Reps program helps push responsibility and authority
@@ -36,7 +36,7 @@ Mozilla Reps - About
       <li>document clearly all his/her activities</li>
     </ul>
     <h4>An open and community-driven program</h4>
-    <p>The Mozilla Reps program is open to anyone 18 and older who is:</p>
+    <p>The Mozilla Reps program is open to anyone 18 or older who is:</p>
     <ul>
       <li>passionate about the Mozilla Project</li>
       <li>knowledgeable of the Mozilla organization, its mission, its

--- a/remo/base/templates/faq.html
+++ b/remo/base/templates/faq.html
@@ -23,7 +23,7 @@ Mozilla Reps - FAQ
     Mozillian who signs up will be asked to fill out a short
     application form and be interviewed on IRC by member(s) of the
     Mozilla Rep council, made up of veteran Mozilla volunteers and
-    staff. NB: you must be 18 years and over to apply.</p>
+    staff. NB: you must be 18 years or older to apply.</p>
     <h4>What sort of activities do Mozilla Reps do?</h4>
     <p>Mozilla Reps are involved in a wide range of activities:</p>
     <ul>
@@ -61,8 +61,8 @@ Mozilla Reps - FAQ
     offers participants a much wider set of tools and resources. Also,
     while the Student Reps program is open to anyone who applies,
     Mozilla Rep applicants need to be “accepted” into the program
-    through a short interview process. NB: you must be 18 years and
-    over to apply.</p>
+    through a short interview process. NB: you must be 18 years or
+    older to apply.</p>
     <h4>What are the incentives for becoming a Mozilla Rep?</h4>
     <p>There many reasons that motivate Mozillians to become Mozilla Reps:</p>
     <ul>


### PR DESCRIPTION
In a couple places it said "18 and over", but one cannot be 18 years old _and_ older at the same time, so I changed it to "18 or older". I didn't file a bug, but I can if it's necessary.
