### PR TITLE
[fix bug 910770] Not all selected nominees are saved for a rangepoll vot...

### DIFF
--- a/media/js/remo/remolib.js
+++ b/media/js/remo/remolib.js
@@ -79,8 +79,10 @@ function append_to_formset(event) {
     function attr_update(selector, attr, prepend){
         new_block_obj.find(selector + prefix + "]").each(function (index, item) {
             var item_obj = $(item);
-            var item_id = item_obj.attr(attr).split('-').pop()
-            newid = prepend + prefix + '-' + total_forms_obj.val() + '-' + item_id;
+            var obj_length = total_forms_obj.val().length;
+            var prologue_length = 2 + prepend.length + prefix.length + obj_length;
+            var item_id = item_obj.attr(attr).substr(prologue_length - obj_length);
+            var newid = prepend + prefix + '-' + total_forms_obj.val() + item_id;
             item_obj.attr(attr, newid);
         });
     }


### PR DESCRIPTION
Taken a pop at fixing this one: 

The bug seems to occur when there are over 10 objects in a form set, due to the attribute strings being concatenated incorrectly given the change in length to `total_forms_obj.val()`.

This PR should fix it, while not breaking the functionality to allow for multiple range poll instances.

Needs testing! (on every page this function is used).
