### PR TITLE
[fix Bug 946655] Improve layout balance on event pages

### DIFF
--- a/remo/base/static/base/css/app-fd4.less
+++ b/remo/base/static/base/css/app-fd4.less
@@ -2275,6 +2275,9 @@ ul.mreports li.editable a {
         p {
             text-align: left;
         }
+        .event-single-attendee-text {
+            text-align: center;
+        }
     }
     .event-comment {
         text-align: left;
@@ -2357,15 +2360,6 @@ ul.mreports li.editable a {
         -moz-box-shadow: 0 2px 5px rgba(0,0,0,0.25);
         -moz-border-radius: 5px;
         border-radius: 5px;
-        -moz-transition:box-shadow .1s ease-in;
-        -webkit-transition:box-shadow .1s ease-in;
-        transition:box-shadow .1s ease-in;
-        &:hover,
-        &:focus {
-            box-shadow: 0 2px 5px gray;
-            -webkit-box-shadow: 0 2px 5px gray;
-            -moz-box-shadow: 0 2px 5px gray;
-        }
     }
     .event-detail {
         time {

--- a/remo/events/templates/view_event.html
+++ b/remo/events/templates/view_event.html
@@ -290,11 +290,42 @@ Mozilla Reps - {{ event.name }}
   </div>
   <!-- END Mashup code -->
 
-  <!-- Next 3 events like this -->
-  {% if similar_events.exists() %}
-    <div class="row">
-      <div class="large-7 columns"></div>
-      <div class="large-5 columns">
+  {% macro display_attendee(attendee) -%}
+    <div class="event-single-attendee">
+      <div class="row">
+        <div class="large-3 small-3 columns grid-profile-image">
+          <img src="{{ attendee|get_avatar_url }}"
+               class="profiles-people-avatar"
+               alt="Avatar">
+        </div>
+        <div class="large-9 small-9 columns grid-profile-text">
+          <h6>{{ attendee.get_full_name() }}</h6>
+          <p class="event-single-attendee-text">
+            {{ get_attendee_role_event(attendee, event) }}
+          </p>
+        </div>
+      </div>
+    </div>
+  {%- endmacro %}
+  <div class="row">
+    <div class="large-7 columns">
+      {% if event.extra_content %}
+        <div class="row">
+          <div class="large-1 columns">
+            <div class="pict-icon large news"></div>
+          </div>
+          <div class="large-11 columns">
+            <!-- Editable Content wiki like -->
+            <div class="markdown">
+              {{ event.extra_content|markdown }}
+            </div>
+          </div>
+        </div>
+      {% endif %}
+    </div>
+    <div class="large-5 columns">
+      <!-- Next 3 events like this -->
+      {% if similar_events.exists() %}
         <div class="row">
           <div class="large-1 columns">
             <div class="pict-icon event large"></div>
@@ -338,44 +369,7 @@ Mozilla Reps - {{ event.name }}
             </ul>
           </div>
         </div>
-      </div>
-    </div>
-  {% endif %}
-  {% macro display_attendee(attendee) -%}
-    <div class="event-single-attendee">
-      <div class="row">
-        <div class="large-3 small-3 columns grid-profile-image">
-          <img src="{{ attendee|get_avatar_url }}"
-               class="profiles-people-avatar"
-               alt="Avatar">
-        </div>
-        <div class="large-9 small-9 columns grid-profile-text">
-          <h6>{{ attendee.get_full_name() }}</h6>
-          <p class="event-single-attendee-text">
-            {{ get_attendee_role_event(attendee, event) }}
-          </p>
-        </div>
-      </div>
-    </div>
-  {%- endmacro %}
-  <div class="row">
-    <div class="large-7 columns">
-      {% if event.extra_content %}
-        <div class="row">
-          <div class="large-1 columns">
-            <div class="pict-icon large news"></div>
-          </div>
-          <div class="large-11 columns">
-            <!-- Editable Content wiki like -->
-            <div class="markdown">
-              {{ event.extra_content|markdown }}
-            </div>
-          </div>
-        </div>
       {% endif %}
-
-    </div>
-    <div class="large-5 columns">
       <div class="row">
         <div class="large-1 columns">
           <div class="pict-icon large people"></div>


### PR DESCRIPTION
- Moves "additional info" up to the right "events like this", to compensate for the empty space.
- Removes the hover/focus styling on the "events like this" calendar date, since these are no longer links.
- Fixes attendee text alignment on small viewport.
