### PR TITLE
[fix bug  971632] Do not explicitly define bug component in event form.

### DIFF
--- a/remo/events/forms.py
+++ b/remo/events/forms.py
@@ -184,7 +184,7 @@ class EventForm(happyforms.ModelForm):
 
         return cdata
 
-    def _clean_bug(self, bug_id, component):
+    def _clean_bug(self, bug_id):
         """Get or create Bug with bug_id and component. """
         if bug_id == '':
             return None
@@ -194,20 +194,18 @@ class EventForm(happyforms.ModelForm):
         except ValueError:
             raise ValidationError('Please provide a number')
 
-        bug, created = Bug.objects.get_or_create(bug_id=bug_id,
-                                                 component=component)
-
+        bug, created = Bug.objects.get_or_create(bug_id=bug_id)
         return bug
 
     def clean_swag_bug_form(self):
         """Clean swag_bug_form field."""
         data = self.cleaned_data['swag_bug_form']
-        return self._clean_bug(data, 'Swag Requests')
+        return self._clean_bug(data)
 
     def clean_budget_bug_form(self):
         """Clean budget_bug_form field."""
         data = self.cleaned_data['budget_bug_form']
-        return self._clean_bug(data, 'Budget Requests')
+        return self._clean_bug(data)
 
     def save(self, *args, **kwargs):
         """Override save on clone event."""

--- a/remo/remozilla/migrations/0007_auto__add_unique_bug_bug_id.py
+++ b/remo/remozilla/migrations/0007_auto__add_unique_bug_bug_id.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding unique constraint on 'Bug', fields ['bug_id']
+        db.create_unique('remozilla_bug', ['bug_id'])
+
+
+    def backwards(self, orm):
+        # Removing unique constraint on 'Bug', fields ['bug_id']
+        db.delete_unique('remozilla_bug', ['bug_id'])
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'remozilla.bug': {
+            'Meta': {'ordering': "['-bug_last_change_time']", 'object_name': 'Bug'},
+            'assigned_to': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'bugs_assigned'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['auth.User']"}),
+            'bug_creation_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'bug_id': ('django.db.models.fields.PositiveIntegerField', [], {'unique': 'True'}),
+            'bug_last_change_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'cc': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'bugs_cced'", 'symmetrical': 'False', 'to': "orm['auth.User']"}),
+            'component': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'council_vote_requested': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'created_on': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'bugs_created'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['auth.User']"}),
+            'first_comment': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'resolution': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '30'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '30'}),
+            'summary': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '500'}),
+            'updated_on': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'whiteboard': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '500'})
+        },
+        'remozilla.status': {
+            'Meta': {'object_name': 'Status'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_updated': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(1969, 12, 31, 0, 0)'})
+        }
+    }
+
+    complete_apps = ['remozilla']

--- a/remo/remozilla/models.py
+++ b/remo/remozilla/models.py
@@ -13,7 +13,7 @@ class Bug(caching.base.CachingMixin, models.Model):
     """Bug model definition."""
     created_on = models.DateTimeField(auto_now_add=True)
     updated_on = models.DateTimeField(auto_now=True)
-    bug_id = models.PositiveIntegerField()
+    bug_id = models.PositiveIntegerField(unique=True)
     bug_creation_time = models.DateTimeField(blank=True, null=True)
     bug_last_change_time = models.DateTimeField(blank=True, null=True)
     creator = models.ForeignKey(User, null=True, blank=True,


### PR DESCRIPTION
When attaching a bug number to events, as Budget or Swag request, the
form relates it to a Bug objects in remozilla.

Because users often mix the Budget with the Swag field -and the other
way around-, the event form tries to find a Bug in remozilla using the
correct id and the wrong category, which will create a new Bug object
with these bogus data.

The fix is to lookup the bug using on the bug id, since Bugzilla
guaranties that the id is unique.
