### PR TITLE
[fix bug 968094] Wrong text at ng-reports section of the dashboard

### DIFF
--- a/remo/base/templates/dashboard_mozillians.html
+++ b/remo/base/templates/dashboard_mozillians.html
@@ -123,19 +123,49 @@
                                     </a>
                                   </td>
                                   <td>
-                                    {{ count_ng_reports(report.user, current_streak=True) }} days
+                                    {% set day_count=count_ng_reports(report.user, current_streak=True) %}
+                                    {% if day_count > 0 %}
+                                      {{ day_count }}&nbsp;
+                                      {% if day_count == 1 %}day{% else %}days{% endif %}
+                                    {% else %}
+                                      0
+                                    {% endif %}
                                   </td>
                                   <td>
-                                    {{ count_ng_reports(report.user, longest_streak=True) }} days
+                                    {% set day_count=count_ng_reports(report.user, longest_streak=True) %}
+                                    {% if day_count > 0 %}
+                                      {{ day_count }}&nbsp;
+                                      {% if day_count == 1 %}day{% else %}days{% endif %}
+                                    {% else %}
+                                      0
+                                    {% endif %}
                                   </td>
                                   <td>
-                                    {{ count_ng_reports(report.user, period=2) }} activities
+                                    {% set activity_count=count_ng_reports(report.user, period=2) %}
+                                    {% if activity_count > 0 %}
+                                      {{ activity_count }}&nbsp;
+                                      {% if activity_count == 1 %}activity{% else %}activities{% endif %}
+                                    {% else %}
+                                      0
+                                    {% endif %}
                                   </td>
                                   <td>
-                                    {{ count_ng_reports(report.user, period=10) }} activities
+                                    {% set activity_count=count_ng_reports(report.user, period=10) %}
+                                    {% if activity_count > 0 %}
+                                      {{ activity_count }}&nbsp;
+                                      {% if activity_count == 1 %}activity{% else %}activities{% endif %}
+                                    {% else %}
+                                      0
+                                    {% endif %}
                                   </td>
                                   <td>
-                                    {{ count_ng_reports(report.user) }} activities
+                                    {% set activity_count=count_ng_reports(report.user) %}
+                                    {% if activity_count > 0 %}
+                                      {{ activity_count }}&nbsp;
+                                      {% if activity_count == 1 %}activity{% else %}activities{% endif %}
+                                    {% else %}
+                                      0
+                                    {% endif %}
                                   </td>
                                 </tr>
                               {% endfor %}

--- a/remo/base/templates/dashboard_reps.html
+++ b/remo/base/templates/dashboard_reps.html
@@ -40,10 +40,11 @@
             <tbody>
               <tr>
                 <td>
-                  {% set activities=count_ng_reports(user, current_streak=True) %}
-                  {{ activities }}
-                  {% if activities > 0 %}
-                    &nbsp;activities<br>
+                  {% set activity_count=count_ng_reports(user, current_streak=True) %}
+                  {% if activity_count > 0 %}
+                    {{ activity_count }}&nbsp;
+                    {% if activity_count == 1 %}activity{% else %}activities{% endif %}
+                    <br>
                     <span class="date-range">
                       {{ date_to_weeks(user.userprofile.current_streak_start,
                                        today.date()) }} weeks<br>
@@ -55,13 +56,16 @@
                           {{ today|strftime('%d %b %Y')}}
                       {% endif %}
                     </span>
+                  {% else %}
+                    0
                   {% endif %}
                 </td>
                 <td>
-                  {% set activities=count_ng_reports(user, longest_streak=True) %}
-                  {{ activities }}
-                  {% if activities > 0 %}
-                    &nbsp;activities<br>
+                  {% set activity_count=count_ng_reports(user, longest_streak=True) %}
+                  {% if activity_count > 0 %}
+                    {{ activity_count }}&nbsp;
+                    {% if activity_count == 1 %}activity{% else %}activities{% endif %}
+                    <br>
                     <span class="date-range">
                       {{ date_to_weeks(user.userprofile.longest_streak_start,
                                        user.userprofile.longest_streak_end) }} weeks<br>
@@ -73,34 +77,48 @@
                           {{ user.userprofile.longest_streak_end|strftime('%d %b %Y')}}
                       {% endif %}
                     </span>
+                  {% else %}
+                    0
                   {% endif %}
                 </td>
                 <td>
-                  {% set activities=count_ng_reports(user, period=2) %}
-                  {{ activities }}
-                  {% if activities > 0 %}
-                    &nbsp;activities<br>
+                  {% set activity_count=count_ng_reports(user, period=2) %}
+                  {% if activity_count > 0 %}
+                    {{ activity_count }}&nbsp;
+                    {% if activity_count == 1 %}activity{% else %}activities{% endif %}
+                    <br>
                     <span class="date-range">
                       {{ get_date_n_weeks_before(today, 2)|strftime('%d %b %Y')}}
                       &nbsp;-&nbsp;
                       {{ today|strftime('%d %b %Y')}}
                     </span>
+                  {% else %}
+                    0
                   {% endif %}
                 </td>
                 <td>
-                  {% set activities=count_ng_reports(user, period=10) %}
-                  {{ activities }}
-                  {% if activities > 0 %}
-                    &nbsp;activities<br>
+                  {% set activity_count=count_ng_reports(user, period=10) %}
+                  {% if activity_count > 0 %}
+                    {{ activity_count }}&nbsp;
+                    {% if activity_count == 1 %}activity{% else %}activities{% endif %}
+                    <br>
                     <span class="date-range">
                       {{ get_date_n_weeks_before(today, 10)|strftime('%d %b %Y')}}
                       &nbsp;-&nbsp;
                       {{ today|strftime('%d %b %Y')}}
                     </span>
+                  {% else %}
+                    0
                   {% endif %}
                 </td>
                 <td>
-                  {{ count_ng_reports(user) }} activities
+                  {% set activity_count=count_ng_reports(user) %} 
+                  {% if activity_count > 0 %}
+                    {{ activity_count }}&nbsp;
+                    {% if activity_count == 1 %}activity{% else %}activities{% endif %}
+                  {% else %}
+                    0
+                  {% endif %}
                 </td>
               </tr>
             </tbody>
@@ -149,11 +167,51 @@
                         {{ reportee.get_full_name() }}
                       </a>
                     </td>
-                    <td>{{ count_ng_reports(reportee, current_streak=True) }} days</td>
-                    <td>{{ count_ng_reports(reportee, longest_streak=True) }} days</td>
-                    <td>{{ count_ng_reports(reportee, period=2) }} activities</td>
-                    <td>{{ count_ng_reports(reportee, period=10) }} activities</td>
-                    <td>{{ count_ng_reports(reportee) }} activities</td>
+                    <td>
+                        {% set day_count=count_ng_reports(reportee, current_streak=True) %}
+                        {% if day_count > 0 %}
+                          {{ day_count }}&nbsp;
+                          {% if day_count == 1 %}day{% else %}days{% endif %}
+                        {% else %}
+                          0
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% set day_count=count_ng_reports(reportee, longest_streak=True) %}
+                        {% if day_count > 0 %}
+                          {{ day_count }}&nbsp;
+                          {% if day_count == 1 %}day{% else %}days{% endif %}
+                        {% else %}
+                          0
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% set activity_count=count_ng_reports(reportee, period=2) %}
+                        {% if activity_count > 0 %}
+                  	  {{ activity_count }}&nbsp;
+                          {% if activity_count == 1 %}activity{% else %}activities{% endif %}
+                        {% else %}
+                          0
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% set activity_count=count_ng_reports(reportee, period=10) %}
+                        {% if activity_count > 0 %}
+                  	  {{ activity_count }}&nbsp;
+                          {% if activity_count == 1 %}activity{% else %}activities{% endif %}
+                        {% else %}
+                          0
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% set activity_count=count_ng_reports(reportee) %}
+                        {% if activity_count > 0 %}
+                  	  {{ activity_count }}&nbsp;
+                          {% if activity_count == 1 %}activity{% else %}activities{% endif %}
+                        {% else %}
+                          0
+                        {% endif %}
+                   </td>
                   </tr>
                 {% endfor %}
               {% endcache %}


### PR DESCRIPTION
This change is the fix for bug https://bugzilla.mozilla.org/show_bug.cgi?id=968094 (968094-Wrong text at ng-reports section of the dashboard).

Issue caused: In dashboard, the text for some quantitative values in ng_reports section were wrong. For example, the singular quantitative value like '1 activity' or '1 day' was appearing in plural form as '1 activities' and '1 days'.

Resolution: count_ng_reports is the method which filters the ng_reports on arguments and returns the count of results. Check for count; if (count equals 1) use singular word; if (count greater than 1)use plural word; if (count equal 0 or less than 0) use 0.
