### PR TITLE
[fix bug 787791] Stop making API calls when full list gets loaded.

### DIFF
--- a/remo/events/static/events/js/events_list.js
+++ b/remo/events/static/events/js/events_list.js
@@ -321,8 +321,7 @@ var update_results = function(data, query, newquery, past_events) {
         set_number_of_events(data.meta.total_count);
     }
 
-    if ((parseInt(data.meta.limit, 10) === 0) ||
-        (parseInt(data.meta.offset, 10) + EventsLib.results_batch >= parseInt(data.meta.total_count, 10))) {
+    if (!data.meta.next) {
         EventsLib.allset = true;
     }
     else {

--- a/remo/profiles/static/profiles/js/profiles_people.js
+++ b/remo/profiles/static/profiles/js/profiles_people.js
@@ -126,8 +126,7 @@ var update_results = function(data, query, newquery, update_pointers) {
         ProfilesLib.table_search_list_elm.empty();
     }
 
-    if ((parseInt(data.meta.limit, 10) === 0) ||
-        (parseInt(data.meta.offset, 10) + ProfilesLib.results_batch >= parseInt(data.meta.total_count, 10))) {
+    if (!data.meta.next) {
         ProfilesLib.allset = true;
         ProfilesLib.profiles_loading_wrapper_elm.hide();
     }


### PR DESCRIPTION
Tastypie upgrade (8757ea5) changed the API behavior when it comes to
'limit' meta data returned to API call. It's now limited to 1000, while
previously respected any limit given. We based parts of our logic on the
limit returned and that caused Events and Reps to be loaded multiple
times by consecutive API calls.

We fix that by watching the meta.next variable which always tells the
truth about the existence of more data, independently of the value of
the limit.
