### PR TITLE
Set check_mozillian_username execution soft time limit.

### DIFF
--- a/remo/profiles/tasks.py
+++ b/remo/profiles/tasks.py
@@ -22,7 +22,7 @@ def send_generic_mail(recipient_list, subject, email_template, data={}):
     send_mail(subject, message, settings.FROM_EMAIL, recipient_list)
 
 
-@periodic_task(run_every=timedelta(hours=8))
+@periodic_task(run_every=timedelta(hours=24), soft_time_limit=300)
 def check_mozillian_username():
     mozillians = User.objects.filter(groups__name='Mozillians')
 


### PR DESCRIPTION
check_mozillian_username has been taking more than 120secs on celery to
complete and thus hitting the execution soft time limit. Raise the time
limit only for this function to 5 mins to solve this.

Also restore the previous execution schedule (once per day) of the task.
