### PR TITLE
[bug 997891] Use failsafe format() to format subject.

### DIFF
--- a/remo/voting/models.py
+++ b/remo/voting/models.py
@@ -169,8 +169,9 @@ def automated_poll_discussion_email(sender, instance, created, raw, **kwargs):
     """Send email reminders when a vote starts/ends."""
     if instance.automated_poll and created:
         template = 'emails/review_budget_notify_council.txt'
-        subject = ('Discuss [Bug %d] - %s'
-                   % (instance.bug.bug_id, instance.bug.summary))
+        subject = ('Discuss [Bug {id}] - {summary}'
+                   .format(id=instance.bug.bug_id,
+                           summary=instance.bug.summary))
         data = {'bug': instance.bug,
                 'BUGZILLA_URL': BUGZILLA_URL}
         send_remo_mail.delay(


### PR DESCRIPTION
Because 'instance' is not yet saved in the db, bug_id is still
unicode and python cannot convert it using '%d'.
