### PR TITLE
Fixes setlocale warnings

### DIFF
--- a/puppet/manifests/classes/custom.pp
+++ b/puppet/manifests/classes/custom.pp
@@ -1,3 +1,7 @@
 # You can add custom puppet manifests for your app here.
 class custom {
+  exec { 'append-lc_ctype-to-environments':
+    command => 'echo "LC_CTYPE=en_US.UTF-8" >> /etc/environment',
+    unless  => 'grep LC_CTYPE="en_US.UTF-8" /etc/environment',
+  }
 }


### PR DESCRIPTION
This fixes the recurrent message displayed on vagrant boxes: 

```
warning: setlocale: LC_CTYPE: cannot change locale (UTF-8)
```
