### PR TITLE
[fix bug 1009018] Responsify HTML tables on Reps

### DIFF
--- a/remo/base/static/base/css/app-fd4.less
+++ b/remo/base/static/base/css/app-fd4.less
@@ -670,17 +670,6 @@ label.required:after {
     }
 }
 
-#featured-articles {
-    width: 100%;
-    border-spacing: 0 0;
-    th {
-        font-size: 14px;
-    }
-    td {
-        font-size: 12px;
-    }
-}
-
 .featured-button {
     .top-margined;
     margin-bottom: 20px;

--- a/remo/base/static/base/css/responsive-tables.css
+++ b/remo/base/static/base/css/responsive-tables.css
@@ -1,0 +1,23 @@
+/* Foundation v2.1.4 http://foundation.zurb.com */
+/* Artfully masterminded by ZURB  */
+
+/* Mobile */
+@media only screen and (max-width: 767px) {
+    
+    table.responsive.on { margin-bottom: 0 !important; }
+    
+    .pinned { position: absolute; left: 0; top: 0; background: #fff; width: 35%; overflow: hidden; overflow-x: scroll; border-right: 1px solid #ccc; border-left: 1px solid #ccc; }
+    .pinned table { border: none; width: 100%; margin-bottom: 0 !important; }
+    .pinned table th, .pinned table td { white-space: nowrap; }
+    .pinned td:last-child { border-bottom: 0; }
+    
+    div.table-wrapper { position: relative; margin-bottom: 20px; overflow: hidden; border-right: 1px solid #ccc; border-top: 1px solid #ccc; border-bottom: 1px solid #ccc;}
+    div.table-wrapper div.scrollable { margin-left: 35%; }
+    div.table-wrapper div.scrollable { overflow: scroll; overflow-y: hidden; } 
+    div.table-wrapper div.scrollable table { border-top: none; border-bottom: none; }   
+    
+    table.responsive.on td, table.responsive.on th { position: relative; white-space: nowrap; overflow: hidden; }
+    table.responsive.on th:first-child, table.responsive.on td:first-child, table.responsive.on td:first-child, table.responsive.pinned td { display: none; }
+    
+    
+}

--- a/remo/base/static/base/js/responsive-tables.js
+++ b/remo/base/static/base/js/responsive-tables.js
@@ -1,0 +1,71 @@
+/* Foundation v2.1.4 http://foundation.zurb.com */
+/* Artfully masterminded by ZURB  */
+
+$(document).ready(function() {
+    var switched = false;
+    var $window = $(window);
+    var updateTables = function() {
+        if (($window.width() < 767) && !switched ){
+            switched = true;
+            $('table.responsive').each(function(i, element) {
+                splitTable($(element));
+            });
+            return true;
+        } else if (switched && ($window.width() > 767)) {
+            switched = false;
+            $('table.responsive').each(function(i, element) {
+                unsplitTable($(element));
+            });
+        }
+    };
+
+    $('table.responsive').addClass('on');
+   
+    $window.load(updateTables);
+    $window.on('redraw', function(){
+        switched=false;
+        updateTables();
+    }); // An event to listen for
+    $window.on('resize', updateTables);
+  
+    function splitTable(original) {
+        original.wrap("<div class='table-wrapper' />");
+        
+        var copy = original.clone();
+        copy.find("td:not(:first-child), th:not(:first-child)").css("display", "none");
+        copy.removeClass("responsive");
+        
+        original.closest(".table-wrapper").append(copy);
+        copy.wrap("<div class='pinned' />");
+        original.wrap("<div class='scrollable' />");
+
+        setCellHeights(original, copy);
+    }
+  
+    function unsplitTable(original) {
+        original.closest(".table-wrapper").find(".pinned").remove();
+        original.unwrap();
+        original.unwrap();
+    }
+
+    function setCellHeights(original, copy) {
+        var tr = original.find('tr'),
+            tr_copy = copy.find('tr'),
+            heights = [];
+
+        tr.each(function (index) {
+            var self = $(this),
+                tx = self.find('th, td');
+
+            tx.each(function () {
+                var height = $(this).outerHeight(true);
+                heights[index] = heights[index] || 0;
+                if (height > heights[index]) heights[index] = height;
+            });
+        });
+
+        tr_copy.each(function (index) {
+          $(this).height(heights[index]);
+        });
+    }
+});

--- a/remo/base/templates/base_fd4.html
+++ b/remo/base/templates/base_fd4.html
@@ -30,6 +30,8 @@
   {% compress css %}
     <link href="{{ static('base/css/foundation-4.css') }}" rel="stylesheet"
           media="screen,projection,tv" />
+    <link href="{{ static('base/css/responsive-tables.css') }}" rel="stylesheet"
+          media="screen,projection,tv" />
   {% endcompress %}
 
   <!--[if lt IE 9]>
@@ -314,6 +316,7 @@
     <script src="{{ static('base/js/jquery-1.7.1.js') }}"></script>
     <script src="{{ static('base/js/modernizr.foundation-4.js') }}"></script>
     <script src="{{ static('base/js/foundation-4.min.js') }}"></script>
+    <script src="{{ static('base/js/responsive-tables.js') }}"></script>
     <script src="{{ static('base/js/jquery.prettydate.js') }}"></script>
     <script src="{{ static('base/js/jquery.imageready.min.js') }}"></script>
     <script src="{{ static('base/js/placeholder.min.js') }}"></script>

--- a/remo/base/templates/dashboard_mozillians.html
+++ b/remo/base/templates/dashboard_mozillians.html
@@ -114,7 +114,7 @@
                            class="dashboard-mozillians-reps-reports-block
                                   dashboard-continuous-reports-mozillians-unavailable
                                   large-12 columns hidden">
-                        <table class="dashboard-table">
+                        <table class="dashboard-table responsive">
                           <thead>
                             <tr>
                               <th>Name</th>
@@ -208,7 +208,7 @@
                   <!-- Current and future events block -->
                   <div class="dashboard-events-future-block">
                     {% if reps_current_events[key] %}
-                      <table class="dashboard-table">
+                      <table class="dashboard-table responsive">
                         <thead>
                           <tr>
                             <th class="dashboard-clickable type-string">Event Name</th>
@@ -256,7 +256,7 @@
                   <!-- Past events block-->
                   <div class="dashboard-events-past-block hidden">
                     {% if reps_past_events[key] %}
-                      <table class="dashboard-table">
+                      <table class="dashboard-table responsive">
                         <thead>
                           <tr>
                             <th class="dashboard-clickable type-string">Event Name</th>

--- a/remo/base/templates/dashboard_reps.html
+++ b/remo/base/templates/dashboard_reps.html
@@ -35,7 +35,7 @@
     <!-- my block -->
     {% if user %}
       <div id="dashboard-continuous-reports-mine-block" class="large-12 columns">
-        <table class="dashboard-table">
+        <table class="dashboard-table responsive">
           <tbody>
             <tr>
               <td>
@@ -130,7 +130,7 @@
     <!-- mentees block -->
     {% if mentees_ng_reportees %}
       <div id="dashboard-continuous-reports-mentees-block" class="large-12 columns hidden">
-        <table class="dashboard-table">
+        <table class="dashboard-table responsive">
           <thead>
             <tr>
               <th>Name</th>
@@ -241,7 +241,7 @@
 <div class="row">
   <div id="dashboard-br-my-block" class="large-12 columns">
     {% if my_budget_requests %}
-      <table class="dashboard-table">
+      <table class="dashboard-table responsive">
         <thead>
           <tr>
             <th class="dashboard-clickable type-int">ID</th>
@@ -309,7 +309,7 @@
   {% if mentees_budget_requests is defined %}
     <div id="dashboard-br-mentees-block" class="large-12 hidden columns">
       {% if mentees_budget_requests %}
-        <table class="dashboard-table">
+        <table class="dashboard-table responsive">
           <thead>
             <tr>
               <th class="dashboard-clickable type-int">ID</th>
@@ -370,7 +370,7 @@
   {% if all_budget_requests is defined %}
     <div id="dashboard-br-all-block" class="large-12 hidden columns">
       {% if all_budget_requests %}
-        <table class="dashboard-table">
+        <table class="dashboard-table responsive">
           <thead>
             <tr>
               <th class="dashboard-clickable type-int">ID</th>
@@ -478,7 +478,7 @@
 <div class="row">
   <div id="dashboard-sr-my-block" class="large-12 columns">
     {% if my_swag_requests %}
-      <table class="dashboard-table">
+      <table class="dashboard-table responsive">
         <thead>
           <tr>
             <th class="dashboard-clickable type-int">ID</th>
@@ -546,7 +546,7 @@
   {% if mentees_swag_requests is defined %}
     <div id="dashboard-sr-mentees-block" class="large-12 hidden columns">
       {% if mentees_swag_requests %}
-        <table class="dashboard-table">
+        <table class="dashboard-table responsive">
           <thead>
             <tr>
               <th class="dashboard-clickable type-int">ID</th>
@@ -607,7 +607,7 @@
   {% if all_swag_requests is defined %}
     <div id="dashboard-sr-all-block" class="large-12 hidden columns">
       {% if all_swag_requests %}
-        <table class="dashboard-table">
+        <table class="dashboard-table responsive">
           <thead>
             <tr>
               <th class="dashboard-clickable type-int">ID</th>
@@ -693,7 +693,7 @@
   <div class="row">
     <div id="dashboard-citr-block" class="large-12 columns">
       {% if my_cit_requests %}
-        <table class="dashboard-table">
+        <table class="dashboard-table responsive">
           <thead>
             <tr>
               <th class="dashboard-clickable type-int">ID</th>
@@ -763,7 +763,7 @@
   <div class="row">
     <div id="dashboard-mentorship-block" class="large-12 columns">
       {% if my_mentorship_requests %}
-        <table class="dashboard-table">
+        <table class="dashboard-table responsive">
           <thead>
             <tr>
               <th class="dashboard-clickable type-int">ID</th>
@@ -834,7 +834,7 @@
   <div class="row">
     <div id="dashboard-mentorship-block" class="large-12 columns">
       {% if my_planning_requests %}
-        <table class="dashboard-table">
+        <table class="dashboard-table responsive">
           <thead>
             <tr>
               <th class="dashboard-clickable type-int">ID</th>
@@ -917,7 +917,7 @@
           <p class="desc">
             Reps without mentors set are displayed here:
           </p>
-          <table class="dashboard-table">
+          <table class="dashboard-table responsive">
             <thead>
               <tr>
                 <th class="dashboard-clickable type-string">Username</th>
@@ -964,7 +964,7 @@
           <p class="desc">
             Reps that are invited but not filled their profiles are displayed here:
           </p>
-          <table class="dashboard-table">
+          <table class="dashboard-table responsive">
             <thead>
               <tr>
                 <th class="dashboard-clickable type-string">Bugzilla Mail</th>

--- a/remo/featuredrep/templates/featuredrep_list.html
+++ b/remo/featuredrep/templates/featuredrep_list.html
@@ -34,7 +34,7 @@
   {% endif %}
   <div class="row">
     <div class="large-12 columns">
-      <table id="featured-articles">
+      <table class="dashboard-table responsive">
         <thead>
           <tr>
             <th>

--- a/remo/reports/templates/list_ng_reports.html
+++ b/remo/reports/templates/list_ng_reports.html
@@ -34,7 +34,7 @@
   {% if number_of_reports > 0 %}
     <div class="row">
       <div class="large-12 columns" id="reports-list">
-        <table class="dashboard-table">
+        <table class="dashboard-table responsive">
           <thead>
             <tr>
               <th>

--- a/remo/voting/templates/list_votings.html
+++ b/remo/voting/templates/list_votings.html
@@ -18,7 +18,7 @@
 
   {% macro display_polls(polls, show_pagination) -%}
     <div class="large-12 columns">
-      <table class="dashboard-table">
+      <table class="dashboard-table responsive">
         <thead>
           <tr>
             <th class="dashboard-clickable type-string">Name</th>


### PR DESCRIPTION
Foundation have a responsive `<table>` plugin that I think could make data-heavy pages on Reps work much nicer on small screens. 

This PR adds responsive tables to `/dashboard`, `/reports` and `/voting` at mobile break-point sizes, which are probably the main pages where this could be of benefit.

The responsive tables work by using an overflow-scrolling area on table data, instead of trying to squeeze everything to the width of the page.
