### PR TITLE
Fix deprecation warnings.

### DIFF
--- a/remo/api/urls.py
+++ b/remo/api/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import include, patterns, url
+from django.conf.urls import include, patterns, url
 
 from tastypie.api import Api
 

--- a/remo/base/content_urls.py
+++ b/remo/base/content_urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from django.core.urlresolvers import reverse_lazy
 
 from remo.base.views import (BaseCreateView, BaseDeleteView, BaseListView,

--- a/remo/base/settings_urls.py
+++ b/remo/base/settings_urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 
 urlpatterns = patterns(

--- a/remo/base/urls.py
+++ b/remo/base/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import include, patterns, url
+from django.conf.urls import include, patterns, url
 from django.views.generic import TemplateView
 
 

--- a/remo/events/e_urls.py
+++ b/remo/events/e_urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns(
     'remo.events.views',

--- a/remo/events/event_urls.py
+++ b/remo/events/event_urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from django.views.generic import RedirectView
 
 

--- a/remo/featuredrep/urls.py
+++ b/remo/featuredrep/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns(
     '',

--- a/remo/profiles/admin.py
+++ b/remo/profiles/admin.py
@@ -1,6 +1,6 @@
 from socket import error as socket_error
 
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from django.contrib import admin, messages
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User

--- a/remo/profiles/people_urls.py
+++ b/remo/profiles/people_urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from django.views.generic import RedirectView
 
 # We use /people/[query] to automatically load the people list view

--- a/remo/profiles/user_urls.py
+++ b/remo/profiles/user_urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import include, patterns, url
+from django.conf.urls import include, patterns, url
 
 urlpatterns = patterns(
     'remo.profiles.views',

--- a/remo/reports/r_urls.py
+++ b/remo/reports/r_urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 OPTIONAL_PARAMETER_REGEX = '(?:/(?P<day>\d+)/(?P<id>\d+))?'
 

--- a/remo/reports/report_urls.py
+++ b/remo/reports/report_urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 
 FUNCTIONAL_AREA_REGEX = 'functional-area/(?P<functional_area_slug>.+)'

--- a/remo/urls.py
+++ b/remo/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls.defaults import include, patterns, url
+from django.conf.urls import include, patterns, url
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 

--- a/remo/voting/v_urls.py
+++ b/remo/voting/v_urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns(
     'remo.voting.views',

--- a/remo/voting/voting_urls.py
+++ b/remo/voting/voting_urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns(
     'remo.voting.views',


### PR DESCRIPTION
- Replace 'django.conf.urls.defaults' with 'django.conf.uls'.
