### PR TITLE
[no bug] Update Mapbox ID for local development

### DIFF
--- a/remo/settings/base.py
+++ b/remo/settings/base.py
@@ -159,6 +159,6 @@ ITEMS_PER_PAGE = 25
 import djcelery
 djcelery.setup_loader()
 
-MAPBOX_TOKEN = 'examples.map-vyofok3q'
+MAPBOX_TOKEN = 'examples.map-i86nkdio'
 
 SERVER_EMAIL = 'reps-dev@mozilla.com'


### PR DESCRIPTION
Mapbox have changed the ID for their example map. This is the new ID they are using in all their online examples now, so we need to switch to using it for local development.
