### PR TITLE
Fix bug 968094. Show singular 'activity' instead of plural 'activities' ...

### DIFF
--- a/remo/base/templates/dashboard_reps.html
+++ b/remo/base/templates/dashboard_reps.html
@@ -67,7 +67,13 @@
                 {% set activities=count_ng_reports(user, current_streak=True) %}
                 {{ activities }}
                 {% if activities > 0 %}
-                  &nbsp;activities<br>
+                  &nbsp;
+                    {% if activities > 1 %}
+                      activities
+                    {% else %}
+                      activity
+                    {% endif %}
+                  <br>
                   <span class="date-range">
                     {{ date_to_weeks(user.userprofile.current_streak_start,
                                       today.date()) }} weeks<br>
@@ -85,7 +91,13 @@
                 {% set activities=count_ng_reports(user, longest_streak=True) %}
                 {{ activities }}
                 {% if activities > 0 %}
-                  &nbsp;activities<br>
+                  &nbsp;
+                    {% if activities > 1 %}
+                      activities
+                    {% else %}
+                      activity
+                    {% endif %}
+                  <br>
                   <span class="date-range">
                     {{ date_to_weeks(user.userprofile.longest_streak_start,
                                       user.userprofile.longest_streak_end) }} weeks<br>
@@ -106,7 +118,13 @@
                 {% set activities=count_ng_reports(user, period=4) %}
                 {{ activities }}
                 {% if activities > 0 %}
-                  &nbsp;activities<br>
+                  &nbsp;
+                    {% if activities > 1 %}
+                      activities
+                    {% else %}
+                      activity
+                    {% endif %}
+                  <br>
                   <span class="date-range">
                     {{ get_date_n_weeks_before(today, 4)|strftime('%d %b %Y')}}
                     &nbsp;-&nbsp;
@@ -118,7 +136,13 @@
                 {% set activities=count_ng_reports(user, period=8) %}
                 {{ activities }}
                 {% if activities > 0 %}
-                  &nbsp;activities<br>
+                  &nbsp;
+                    {% if activities > 1 %}
+                      activities
+                    {% else %}
+                      activity
+                    {% endif %}
+                  <br>
                   <span class="date-range">
                     {{ get_date_n_weeks_before(today, 8)|strftime('%d %b %Y')}}
                     &nbsp;-&nbsp;
@@ -127,7 +151,13 @@
                 {% endif %}
               </td>
               <td>
-                {{ count_ng_reports(user) }} activities
+                {% set activities=count_ng_reports(user) %}
+                {{ activities }}
+                {% if activities > 1 %}
+                  activities
+                {% else %}
+                  activity
+                {% endif %}
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
...when there is only one activity in the new reports dashboard
