### PR TITLE
Populate ActionItem model from bugzilla, polls and events.

### DIFF
--- a/remo/base/helpers.py
+++ b/remo/base/helpers.py
@@ -180,7 +180,8 @@ def user_is_mozillian(user):
 @register.function
 def user_is_rep(user):
     """Check if a user belongs to Rep's group."""
-    return user.groups.filter(name='Rep').exists()
+    return (user.groups.filter(name='Rep').exists() and
+            user.userprofile.registration_complete)
 
 
 @register.function

--- a/remo/dashboard/admin.py
+++ b/remo/dashboard/admin.py
@@ -9,9 +9,9 @@ class ActionItemAdmin(ExportMixin, admin.ModelAdmin):
     model = ActionItem
 
     list_display = ('__unicode__', 'user', 'due_date', 'created_on',
-                    'updated_on')
+                    'priority', 'updated_on')
     search_fields = ['user__first_name', 'user__last_name',
-                     'user__userprofile__display_name']
+                     'user__userprofile__display_name', 'name']
     list_filter = ['name']
 
 

--- a/remo/dashboard/migrations/0002_auto__del_field_actionitem_name__del_field_actionitem_slug__add_field_.py
+++ b/remo/dashboard/migrations/0002_auto__del_field_actionitem_name__del_field_actionitem_slug__add_field_.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'ActionItem.slug'
+        db.delete_column(u'dashboard_actionitem', 'slug')
+
+        # Adding field 'ActionItem.resolved'
+        db.add_column(u'dashboard_actionitem', 'resolved',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+        # Adding field 'ActionItem.completed'
+        db.add_column(u'dashboard_actionitem', 'completed',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+        # Adding field 'ActionItem.content_type'
+        db.add_column(u'dashboard_actionitem', 'content_type',
+                      self.gf('django.db.models.fields.related.ForeignKey')(default=None, to=orm['contenttypes.ContentType']),
+                      keep_default=False)
+
+        # Adding field 'ActionItem.object_id'
+        db.add_column(u'dashboard_actionitem', 'object_id',
+                      self.gf('django.db.models.fields.PositiveIntegerField')(default=None),
+                      keep_default=False)
+
+
+        # Changing field 'ActionItem.due_date'
+        db.alter_column(u'dashboard_actionitem', 'due_date', self.gf('django.db.models.fields.DateField')(null=True))
+        # Adding unique constraint on 'ActionItem', fields ['name', 'object_id', 'user']
+        db.create_unique(u'dashboard_actionitem', ['name', 'object_id', 'user_id'])
+
+
+    def backwards(self, orm):
+        # Removing unique constraint on 'ActionItem', fields ['name', 'object_id', 'user']
+        db.delete_unique(u'dashboard_actionitem', ['name', 'object_id', 'user_id'])
+
+        # Adding field 'ActionItem.slug'
+        db.add_column(u'dashboard_actionitem', 'slug',
+                      self.gf('django.db.models.fields.SlugField')(default='', max_length=255, blank=True),
+                      keep_default=False)
+
+        # Deleting field 'ActionItem.resolved'
+        db.delete_column(u'dashboard_actionitem', 'resolved')
+
+        # Deleting field 'ActionItem.completed'
+        db.delete_column(u'dashboard_actionitem', 'completed')
+
+        # Deleting field 'ActionItem.content_type'
+        db.delete_column(u'dashboard_actionitem', 'content_type_id')
+
+        # Deleting field 'ActionItem.object_id'
+        db.delete_column(u'dashboard_actionitem', 'object_id')
+
+
+        # Changing field 'ActionItem.due_date'
+        db.alter_column(u'dashboard_actionitem', 'due_date', self.gf('django.db.models.fields.DateField')(default=None))
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'dashboard.actionitem': {
+            'Meta': {'ordering': "['-due_date', '-updated_on', '-created_on']", 'unique_together': "(('name', 'user', 'object_id'),)", 'object_name': 'ActionItem'},
+            'completed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            'created_on': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'due_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'priority': ('django.db.models.fields.IntegerField', [], {}),
+            'resolved': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'updated_on': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'action_items_assigned'", 'to': u"orm['auth.User']"})
+        }
+    }
+
+    complete_apps = ['dashboard']

--- a/remo/dashboard/tests/test_models.py
+++ b/remo/dashboard/tests/test_models.py
@@ -1,0 +1,364 @@
+from datetime import timedelta
+
+from django.contrib.auth.models import Group
+from django.contrib.contenttypes.models import ContentType
+from django.utils.timezone import now
+
+from nose.tools import eq_, ok_
+
+from remo.base.tests import RemoTestCase
+from remo.dashboard.models import ActionItem
+from remo.events.models import Event
+from remo.events.tasks import notify_event_owners_to_input_metrics
+from remo.events.tests import EventFactory, EventMetricOutcomeFactory
+from remo.profiles.tests import UserFactory
+from remo.remozilla.models import Bug
+from remo.remozilla.tests import BugFactory
+from remo.voting.models import Poll
+from remo.voting.tasks import resolve_action_items
+from remo.voting.tests import PollFactory, VoteFactory
+
+
+class RemozillaActionItems(RemoTestCase):
+    """Test related to new action items created from bugzilla."""
+
+    def test_waiting_receipts(self):
+        model = ContentType.objects.get_for_model(Bug)
+        items = ActionItem.objects.filter(content_type=model)
+        ok_(not items.exists())
+
+        whiteboard = '[waiting receipts]'
+        user = UserFactory.create(groups=['Rep'])
+        BugFactory.create(whiteboard=whiteboard, assigned_to=user)
+
+        items = ActionItem.objects.filter(content_type=model)
+        eq_(items.count(), 1)
+        eq_(items[0].name, 'Add receipts to bug')
+        eq_(items[0].user, user)
+        eq_(items[0].priority, ActionItem.NORMAL)
+
+    def test_waiting_multiple_documents(self):
+        model = ContentType.objects.get_for_model(Bug)
+        items = ActionItem.objects.filter(content_type=model)
+        ok_(not items.exists())
+
+        whiteboard = '[waiting receipts][waiting report][waiting photos]'
+        user = UserFactory.create(groups=['Rep'])
+        BugFactory.create(whiteboard=whiteboard, assigned_to=user)
+
+        items = ActionItem.objects.filter(content_type=model)
+        eq_(items.count(), 3)
+
+        namelist = ['Add receipts to bug', 'Add report to bug',
+                    'Add photos to bug']
+
+        for item in items:
+            ok_(item.name in namelist)
+            eq_(item.user, user)
+            eq_(item.priority, ActionItem.NORMAL)
+
+    def test_update_bug_whiteboard(self):
+        model = ContentType.objects.get_for_model(Bug)
+        items = ActionItem.objects.filter(content_type=model)
+        ok_(not items.exists())
+
+        whiteboard = '[waiting receipts][waiting report][waiting photos]'
+        user = UserFactory.create(groups=['Rep'])
+        bug = BugFactory.create(whiteboard=whiteboard, assigned_to=user)
+
+        items = ActionItem.objects.filter(content_type=model)
+        eq_(items.count(), 3)
+
+        bug.whiteboard = ""
+        bug.save()
+
+        items = ActionItem.objects.filter(content_type=model)
+        for item in items:
+            ok_(item.completed)
+            ok_(item.resolved)
+
+    def test_mentor_validation(self):
+        model = ContentType.objects.get_for_model(Bug)
+        items = ActionItem.objects.filter(content_type=model)
+
+        ok_(not items.exists())
+
+        mentor = UserFactory.create(groups=['Rep', 'Mentor'])
+        user = UserFactory.create(groups=['Rep'],
+                                  userprofile__mentor=mentor)
+
+        BugFactory.create(pending_mentor_validation=True, assigned_to=user)
+
+        items = ActionItem.objects.filter(content_type=model)
+        eq_(items.count(), 1)
+        eq_(items[0].name, 'Waiting mentor validation')
+        eq_(items[0].user, mentor)
+        eq_(items[0].priority, ActionItem.BLOCKER)
+
+    def test_mentor_change_update_action_items(self):
+        model = ContentType.objects.get_for_model(Bug)
+        items = ActionItem.objects.filter(content_type=model)
+
+        ok_(not items.exists())
+
+        mentor = UserFactory.create(groups=['Rep', 'Mentor'])
+        user = UserFactory.create(groups=['Rep'],
+                                  userprofile__mentor=mentor)
+
+        BugFactory.create(pending_mentor_validation=True, assigned_to=user)
+
+        new_mentor = UserFactory.create(groups=['Rep', 'Mentor'])
+        user.userprofile.mentor = new_mentor
+        user.userprofile.save()
+
+        items = ActionItem.objects.filter(content_type=model)
+        eq_(items[0].user, new_mentor)
+
+    def test_resolve_mentor_validation(self):
+        model = ContentType.objects.get_for_model(Bug)
+        items = ActionItem.objects.filter(content_type=model)
+
+        ok_(not items.exists())
+
+        mentor = UserFactory.create(groups=['Rep', 'Mentor'])
+        user = UserFactory.create(groups=['Rep'],
+                                  userprofile__mentor=mentor)
+
+        bug = BugFactory.create(pending_mentor_validation=True,
+                                assigned_to=user)
+
+        items = ActionItem.objects.filter(content_type=model)
+        eq_(items.count(), 1)
+        eq_(items[0].name, 'Waiting mentor validation')
+        eq_(items[0].user, mentor)
+        eq_(items[0].priority, ActionItem.BLOCKER)
+
+        bug.pending_mentor_validation = False
+        bug.save()
+
+        items = ActionItem.objects.filter(content_type=model)
+        for item in items:
+            ok_(item.completed)
+            ok_(item.resolved)
+
+    def test_needinfo(self):
+        model = ContentType.objects.get_for_model(Bug)
+        items = ActionItem.objects.filter(content_type=model)
+
+        ok_(not items.exists())
+
+        needinfo = UserFactory.create(groups=['Rep'])
+        user = UserFactory.create(groups=['Rep'])
+        bug = BugFactory.create(assigned_to=user)
+        bug.budget_needinfo.add(needinfo)
+        bug.save()
+
+        items = ActionItem.objects.filter(content_type=model)
+        ok_(items.count(), 1)
+
+        for item in items:
+            eq_(item.name, 'Pending open questions')
+            eq_(item.user, needinfo)
+            ok_(item.priority, ActionItem.MINOR)
+
+    def test_remove_needinfo(self):
+        model = ContentType.objects.get_for_model(Bug)
+        items = ActionItem.objects.filter(content_type=model)
+
+        user = UserFactory.create(groups=['Rep'])
+        bug = BugFactory.create()
+        bug.budget_needinfo.add(user)
+        bug.save()
+
+        bug.budget_needinfo.clear()
+        bug.save()
+
+        items = ActionItem.objects.filter(content_type=model)
+        for item in items:
+            ok_(item.completed)
+            ok_(item.resolved)
+
+    def test_council_reviewer_assigned(self):
+        model = ContentType.objects.get_for_model(Bug)
+        items = ActionItem.objects.filter(content_type=model)
+        ok_(not items.exists())
+
+        user = UserFactory.create(groups=['Rep', 'Council'])
+        BugFactory.create(assigned_to=user, council_member_assigned=True)
+
+        items = ActionItem.objects.filter(content_type=model)
+        eq_(items.count(), 1)
+        eq_(items[0].name, 'Review budget request bug')
+        eq_(items[0].user, user)
+        eq_(items[0].priority, ActionItem.BLOCKER)
+
+    def test_council_reviewer_removed(self):
+        model = ContentType.objects.get_for_model(Bug)
+        items = ActionItem.objects.filter(content_type=model)
+        ok_(not items.exists())
+
+        user = UserFactory.create(groups=['Council'])
+        bug = BugFactory.create(assigned_to=user, council_member_assigned=True)
+
+        bug.council_member_assigned = False
+        bug.save()
+
+        items = ActionItem.objects.filter(content_type=model)
+        for item in items:
+            ok_(item.completed)
+            ok_(item.resolved)
+
+
+class VotingActionItems(RemoTestCase):
+    def test_vote_action_item(self):
+        model = ContentType.objects.get_for_model(Poll)
+        items = ActionItem.objects.filter(content_type=model)
+        ok_(not items.exists())
+
+        council = Group.objects.get(name='Council')
+        user = UserFactory.create(groups=['Council'])
+        PollFactory.create(valid_groups=council)
+
+        items = ActionItem.objects.filter(content_type=model)
+        eq_(items.count(), 1)
+
+        for item in items:
+            eq_(item.name, 'Cast your vote')
+            eq_(item.user, user)
+            ok_(item.priority, ActionItem.NORMAL)
+            ok_(not item.completed)
+
+    def test_resolve_vote_action_item(self):
+        model = ContentType.objects.get_for_model(Poll)
+        items = ActionItem.objects.filter(content_type=model)
+        ok_(not items.exists())
+
+        council = Group.objects.get(name='Council')
+        user = UserFactory.create(groups=['Council'])
+        poll = PollFactory.create(valid_groups=council)
+
+        VoteFactory.create(poll=poll, user=user)
+
+        items = ActionItem.objects.filter(content_type=model)
+        eq_(items.count(), 1)
+
+        for item in items:
+            ok_(item.completed)
+            ok_(item.resolved)
+
+    def test_update_vote_due_date(self):
+        model = ContentType.objects.get_for_model(Poll)
+        items = ActionItem.objects.filter(content_type=model)
+        ok_(not items.exists())
+
+        council = Group.objects.get(name='Council')
+        UserFactory.create(groups=['Council'])
+        poll = PollFactory.create(valid_groups=council)
+
+        poll.end = poll.end + timedelta(days=4)
+        poll.save()
+
+        items = ActionItem.objects.filter(content_type=model)
+        eq_(items.count(), 1)
+
+        for item in items:
+            eq_(item.due_date, poll.end.date())
+
+    def test_resolved_past_vote(self):
+        model = ContentType.objects.get_for_model(Poll)
+        items = ActionItem.objects.filter(content_type=model)
+        ok_(not items.exists())
+
+        council = Group.objects.get(name='Council')
+        UserFactory.create(groups=['Council'])
+        PollFactory.create(valid_groups=council,
+                           end=now() - timedelta(days=1))
+
+        items = ActionItem.objects.filter(content_type=model)
+        eq_(items.count(), 1)
+
+        resolve_action_items()
+        items = ActionItem.objects.filter(content_type=model)
+        for item in items:
+            ok_(item.resolved)
+            ok_(not item.completed)
+
+    def test_update_valid_groups(self):
+        model = ContentType.objects.get_for_model(Poll)
+        items = ActionItem.objects.filter(content_type=model)
+        ok_(not items.exists())
+
+        council = Group.objects.get(name='Council')
+        reps = Group.objects.get(name='Rep')
+        UserFactory.create_batch(3, groups=['Council'])
+        UserFactory.create_batch(4, groups=['Rep'])
+        poll = PollFactory.create(valid_groups=council)
+        poll.valid_groups = reps
+        poll.save()
+
+        items = ActionItem.objects.filter(content_type=model)
+        eq_(items.count(), 4)
+
+        for user in reps.user_set.all():
+            ok_(items.filter(user=user).exists())
+
+        for user in council.user_set.all():
+            ok_(not items.filter(user=user).exists())
+
+
+class EventActionItems(RemoTestCase):
+    def test_post_event_metrics(self):
+        model = ContentType.objects.get_for_model(Event)
+        items = ActionItem.objects.filter(content_type=model)
+        ok_(not items.exists())
+
+        start = now() - timedelta(days=4)
+        end = now() - timedelta(days=1)
+        user = UserFactory.create(groups=['Rep'])
+        EventFactory.create(owner=user, start=start, end=end)
+        notify_event_owners_to_input_metrics()
+
+        items = ActionItem.objects.filter(content_type=model)
+        eq_(items.count(), 1)
+
+    def test_resolve_post_event_metrics(self):
+        model = ContentType.objects.get_for_model(Event)
+        items = ActionItem.objects.filter(content_type=model)
+        ok_(not items.exists())
+
+        start = now() - timedelta(days=4)
+        end = now() - timedelta(days=1)
+        user = UserFactory.create(groups=['Rep'])
+        event = EventFactory.create(owner=user, start=start, end=end)
+        notify_event_owners_to_input_metrics()
+        items = ActionItem.objects.filter(content_type=model)
+
+        eq_(items.count(), 1)
+
+        EventMetricOutcomeFactory.create(event=event)
+
+        for item in items:
+            ok_(item.completed)
+            ok_(item.resolved)
+
+    def test_update_event_owner(self):
+        model = ContentType.objects.get_for_model(Event)
+        items = ActionItem.objects.filter(content_type=model)
+        ok_(not items.exists())
+
+        start = now() - timedelta(days=4)
+        end = now() - timedelta(days=1)
+        user = UserFactory.create(groups=['Rep'])
+        event = EventFactory.create(owner=user, start=start, end=end)
+        notify_event_owners_to_input_metrics()
+
+        items = ActionItem.objects.filter(content_type=model)
+        eq_(items.count(), 1)
+
+        new_owner = UserFactory.create(groups=['Rep'])
+        event.owner = new_owner
+        event.save()
+
+        items = ActionItem.objects.filter(content_type=model)
+        eq_(items.count(), 1)
+        eq_(items[0].user, new_owner)

--- a/remo/dashboard/tests/test_views.py
+++ b/remo/dashboard/tests/test_views.py
@@ -1,4 +1,3 @@
-
 from datetime import timedelta
 
 from django.conf import settings

--- a/remo/events/tasks.py
+++ b/remo/events/tasks.py
@@ -4,6 +4,7 @@ from celery.task import periodic_task
 
 from remo.base.tasks import send_remo_mail
 from remo.base.utils import get_date
+from remo.dashboard.models import ActionItem
 from remo.events.models import Event
 
 
@@ -28,3 +29,4 @@ def notify_event_owners_to_input_metrics():
         data = {'event': event}
         send_remo_mail(subject=subject, email_template=template,
                        recipients_list=[event.owner.id], data=data)
+        ActionItem.create(instance=event)

--- a/remo/events/tests/test_tasks.py
+++ b/remo/events/tests/test_tasks.py
@@ -6,7 +6,6 @@ from mock import call, patch
 from nose.tools import eq_, ok_
 
 from remo.base.tests import RemoTestCase
-from remo.base.utils import get_date
 from remo.events.tasks import notify_event_owners_to_input_metrics
 from remo.events.tests import EventFactory
 from remo.profiles.tests import UserFactory
@@ -15,7 +14,8 @@ from remo.profiles.tests import UserFactory
 class SendEventNotificationsTests(RemoTestCase):
     def test_base(self):
         owner = UserFactory.create()
-        event = EventFactory.create(end=get_date(days=-1), owner=owner)
+        end = now() - timedelta(days=1)
+        event = EventFactory.create(end=end, owner=owner)
 
         subject = ('[Reminder] Please add the actual metrics for event {0}'
                    .format(event.name))

--- a/remo/remozilla/fixtures/demo_bugs.json
+++ b/remo/remozilla/fixtures/demo_bugs.json
@@ -13,7 +13,7 @@
             "summary": "",
             "bug_id": 1199,
             "created_on": "2012-03-13 07:45:41+00:00",
-            "assigned_to": null,
+            "assigned_to": 7,
             "bug_last_change_time": null,
             "updated_on": "2012-03-13 07:45:41+00:00",
             "resolution": "",

--- a/remo/remozilla/models.py
+++ b/remo/remozilla/models.py
@@ -1,12 +1,26 @@
 from datetime import datetime
 
 from django.contrib.auth.models import User
+from django.contrib.contenttypes import generic
+from django.contrib.contenttypes.models import ContentType
 from django.db import models
-from django.db.models.signals import pre_save
+from django.db.models.signals import m2m_changed, pre_save
 from django.dispatch import receiver
 from django.utils.timezone import utc
 
 import caching.base
+
+from remo.base.helpers import user_is_rep
+from remo.dashboard.models import ActionItem, Item
+
+
+ADD_RECEIPTS_ACTION = 'Add receipts to bug'
+ADD_REPORT_ACTION = 'Add report to bug'
+ADD_PHOTOS_ACTION = 'Add photos to bug'
+ADD_REPORTS_PHOTOS_ACTION = 'Add reports/photos to bug'
+REVIEW_BUDGET_REQUEST_ACTION = 'Review budget request bug'
+WAITING_MENTOR_VALIDATION_ACTION = 'Waiting mentor validation'
+NEEDINFO_ACTION = 'Pending open questions'
 
 
 class Bug(caching.base.CachingMixin, models.Model):
@@ -33,6 +47,7 @@ class Bug(caching.base.CachingMixin, models.Model):
     council_member_assigned = models.BooleanField(default=False)
     pending_mentor_validation = models.BooleanField(default=False)
     budget_needinfo = models.ManyToManyField(User)
+    action_items = generic.GenericRelation(ActionItem)
 
     objects = caching.base.CachingManager()
 
@@ -54,6 +69,83 @@ class Bug(caching.base.CachingMixin, models.Model):
     @property
     def waiting_photos(self):
         return '[waiting photos]' in self.whiteboard
+
+    def get_action_items(self):
+        if not self.assigned_to or not user_is_rep(self.assigned_to):
+            return []
+
+        action_items = []
+        names = [
+            (ADD_RECEIPTS_ACTION, 'waiting_receipts', ActionItem.NORMAL),
+            (ADD_REPORT_ACTION, 'waiting_report', ActionItem.NORMAL),
+            (ADD_PHOTOS_ACTION, 'waiting_photos', ActionItem.NORMAL),
+            (ADD_REPORTS_PHOTOS_ACTION,
+             'waiting_report_photos', ActionItem.NORMAL),
+            (REVIEW_BUDGET_REQUEST_ACTION,
+             'council_member_assigned', ActionItem.BLOCKER)
+        ]
+
+        for action_name, attr, priority in names:
+            if getattr(self, attr, None):
+                action_item = Item(action_name, self.assigned_to,
+                                   priority, None)
+                action_items.append(action_item)
+            else:
+                ActionItem.resolve(instance=self, user=self.assigned_to,
+                                   name=action_name)
+
+        action_name = WAITING_MENTOR_VALIDATION_ACTION
+        if self.assigned_to and user_is_rep(self.assigned_to):
+            mentor = self.assigned_to.userprofile.mentor
+            if self.pending_mentor_validation:
+                action_item = Item(action_name, mentor,
+                                   ActionItem.BLOCKER, None)
+                action_items.append(action_item)
+            else:
+                ActionItem.resolve(instance=self, user=mentor,
+                                   name=action_name)
+
+        action_name = NEEDINFO_ACTION
+        for user in self.budget_needinfo.all():
+            action_item = Item(action_name, user, ActionItem.CRITICAL, None)
+            action_items.append(action_item)
+
+        return action_items
+
+    def save(self, *args, **kwargs):
+        # Update action items
+        action_model = ContentType.objects.get_for_model(self)
+        if self.pk:
+            names = [ADD_RECEIPTS_ACTION, ADD_REPORT_ACTION,
+                     ADD_PHOTOS_ACTION, ADD_REPORTS_PHOTOS_ACTION,
+                     REVIEW_BUDGET_REQUEST_ACTION]
+
+            current_bug = Bug.objects.get(id=self.pk)
+            action_items = ActionItem.objects.filter(content_type=action_model,
+                                                     object_id=self.pk)
+
+            if current_bug.assigned_to != self.assigned_to:
+                items = action_items.filter(name__in=names)
+                items.update(user=self.assigned_to)
+
+            try:
+                current_mentor = current_bug.assigned_to.userprofile.mentor
+                new_mentor = self.assigned_to.userprofile.mentor
+            except AttributeError:
+                current_mentor = None
+                new_mentor = None
+
+            if current_mentor != new_mentor:
+                action_name = WAITING_MENTOR_VALIDATION_ACTION
+                items = action_items.filter(name=action_name)
+                items.update(user=new_mentor)
+
+        super(Bug, self).save(*args, **kwargs)
+
+        if self.status == 'RESOLVED':
+            items = ActionItem.objects.filter(content_type=action_model,
+                                              object_id=self.pk)
+            items.update(resolved=True)
 
     class Meta:
         ordering = ['-bug_last_change_time']
@@ -83,3 +175,22 @@ def set_uppercase_pre_save(sender, instance, **kwargs):
         instance.status = instance.status.upper()
     if instance.resolution:
         instance.resolution = instance.resolution.upper()
+
+
+@receiver(m2m_changed, sender=Bug.budget_needinfo.through,
+          dispatch_uid='update_needinfo_signal')
+def update_budget_needinfo_action_items(sender, instance, action, pk_set,
+                                        **kwargs):
+    """Update ActionItem objects on needinfo change."""
+    name = 'Pending open questions'
+    if action == 'post_remove':
+        for pk in pk_set:
+            ActionItem.resolve(instance=instance, user=User.objects.get(pk=pk),
+                               name=name)
+
+    if action == 'post_clear':
+        for user in instance.budget_needinfo.all():
+            ActionItem.resolve(instance=instance, user=user, name=name)
+
+    if action == 'post_add':
+        ActionItem.create(instance=instance)

--- a/remo/remozilla/tests/test_models.py
+++ b/remo/remozilla/tests/test_models.py
@@ -1,7 +1,8 @@
 from nose.tools import eq_
 from test_utils import TestCase
 
-from remo.remozilla.models import Bug
+from remo.profiles.tests import UserFactory
+from remo.remozilla.tests import BugFactory
 
 
 class ModelTest(TestCase):
@@ -9,8 +10,10 @@ class ModelTest(TestCase):
 
     def test_uppercase_status(self):
         """Test that status and resolution are always saved in uppercase."""
-        bug = Bug(bug_id=0000, status="foo", resolution="bar")
-        bug.save()
+        mentor = UserFactory.create()
+        user = UserFactory.create(userprofile__mentor=mentor)
+        bug = BugFactory.create(bug_id=0000, status='foo',
+                                resolution='bar', assigned_to=user)
 
-        eq_(bug.status, "FOO")
-        eq_(bug.resolution, "BAR")
+        eq_(bug.status, 'FOO')
+        eq_(bug.resolution, 'BAR')

--- a/remo/remozilla/tests/test_tasks.py
+++ b/remo/remozilla/tests/test_tasks.py
@@ -59,7 +59,9 @@ class FetchBugsTest(TestCase):
 
         first_request = requests.Request()
         first_request.status_code = 200
-        user = UserFactory.create(groups=['Rep'], email='foo@example.com')
+        mentor = UserFactory.create()
+        user = UserFactory.create(groups=['Rep'], email='foo@example.com',
+                                  userprofile__mentor=mentor)
         bug_data = {'bugs': [{'id': 7788,
                               'summary': 'This is summary',
                               'creator': {'name': 'rep@example.com'},

--- a/remo/settings/base.py
+++ b/remo/settings/base.py
@@ -15,12 +15,12 @@ INSTALLED_APPS = (['south'] +
                       'remo.base',
                       'remo.profiles',
                       'remo.featuredrep',
+                      'remo.dashboard',
                       'remo.remozilla',
                       'remo.reports',
                       'remo.api',
                       'remo.events',
                       'remo.voting',
-                      'remo.dashboard',
 
                       'django_browserid',
                       'jingo_offline_compressor',

--- a/remo/voting/tasks.py
+++ b/remo/voting/tasks.py
@@ -1,14 +1,17 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 from operator import or_
 
 from celery.task import periodic_task, task
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.contrib.contenttypes.models import ContentType
 from django.core.mail import send_mail
 from django.template.loader import render_to_string
 
 from remo.base.tasks import send_remo_mail
 from remo.base.utils import get_date
+from remo.dashboard.models import ActionItem
+
 
 EXTEND_VOTING_PERIOD = 24 * 3600  # 24 hours
 NOTIFICATION_INTERVAL = 24 * 3600  # 24 hours
@@ -79,3 +82,17 @@ def extend_voting_period():
                                      recipients_list=recipients,
                                      email_template=template,
                                      data=ctx_data)
+
+
+@periodic_task(run_every=timedelta(days=1))
+def resolve_action_items():
+    # avoid circular dependencies
+    from remo.voting.models import Poll
+
+    start = datetime.combine(get_date(days=-1), datetime.min.time())
+    end = datetime.combine(get_date(days=-1), datetime.max.time())
+    polls = Poll.objects.filter(end__range=[start, end])
+    action_model = ContentType.objects.get_for_model(Poll)
+    items = ActionItem.objects.filter(content_type=action_model,
+                                      object_id__in=polls)
+    items.update(resolved=True)

--- a/remo/voting/tests/test_tasks.py
+++ b/remo/voting/tests/test_tasks.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from django.contrib.auth.models import Group, User
 from django.core import mail
 from django.utils.timezone import now
@@ -22,8 +24,8 @@ class VotingTestTasks(TestCase):
     def test_extend_voting_period_no_majority(self):
         bug = BugFactory.create()
         start = now().replace(microsecond=0)
-        end = get_date(days=1)
-        new_end = get_date(days=2)
+        end = datetime.combine(get_date(days=1), datetime.min.time())
+        new_end = datetime.combine(get_date(days=2), datetime.min.time())
 
         user = UserFactory.create(groups=['Admin'])
         group = Group.objects.get(name='Council')
@@ -66,7 +68,7 @@ class VotingTestTasks(TestCase):
     def test_extend_voting_period_majority(self):
         bug = BugFactory.create()
         start = now().replace(microsecond=0)
-        end = get_date(days=1)
+        end = datetime.combine(get_date(days=1), datetime.min.time())
 
         user = UserFactory.create(groups=['Admin'])
         group = Group.objects.get(name='Council')


### PR DESCRIPTION
- Sync [waiting <item>] action items from bugzilla.
- Sync pending_mentor_validation action items from bugzilla.
- Sync budget_needinfo action items from bugzilla.
- Sync council reviewer assignment action items from bugzilla.
- Change ActionItem model fields.
- Create action items only for bugs assigned to Reps.
- Add new action item on new poll.
- Resolve action item on new vote.
- Add new action item to submit post event metrics.
- Resolve action item when post event metrics are submitted.
