### PR TITLE
[fix bug 1082674] Do not force 12h format in datetimewidgets.

### DIFF
--- a/vendor-local/lib/python/datetimewidgets.py
+++ b/vendor-local/lib/python/datetimewidgets.py
@@ -133,8 +133,6 @@ class SelectTimeWidget(Widget):
             if (self.meridiem_val.lower().startswith('p') and
                     hour_val > 12 and hour_val < 24):
                 hour_val = hour_val % 12
-        elif hour_val == 0:
-            hour_val = 12
 
         output = []
         if 'id' in self.attrs:


### PR DESCRIPTION
- PEP8 fixes
