### PR TITLE
 [fix bug 1096389] Text that is too long is hidden with an ellipsis

### DIFF
--- a/remo/base/static/base/css/app-fd4.less
+++ b/remo/base/static/base/css/app-fd4.less
@@ -3255,6 +3255,13 @@ table tr.assigned-request:nth-of-type(2n) {
                 font-size: 12px;
             }
         }
+        th:first-child,
+        td:first-child{
+            max-width:100px;
+            overflow:hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
         thead tr {
             height: 45px;
         }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1096389

In this version, the text is clipped at the end and the end is replaced with an ellipsis.
