### PR TITLE
Add some space between Featured Reps

### DIFF
--- a/remo/base/static/base/css/app-fd4.less
+++ b/remo/base/static/base/css/app-fd4.less
@@ -628,6 +628,15 @@ label.required:after {
     border-radius: 5px;
 }
 
+#featured-reps {
+    .row {
+        margin-top: 1em;
+    }
+    h3 {
+        margin-bottom: 0em;
+    }
+}
+
 /* -----------------------------------------
    Featured reps Styles
 ----------------------------------------- */

--- a/remo/base/templates/main.html
+++ b/remo/base/templates/main.html
@@ -59,13 +59,13 @@
     </div>
 
     <!-- Featured Rep section -->
-    <div class="large-4 columns main-section">
+    <div class="large-4 columns main-section" id="featured-reps">
       <h3>
         Rep of the month
       </h3>
-      <div class="row">
-        {% if featuredrep %}
-          {% for user in featuredrep.users.all() %}
+      {% if featuredrep %}
+        {% for user in featuredrep.users.all() %}
+          <div class="row">
             <div class="large-4 columns">
               <img src="{{ user|get_avatar_url(80) }}" id="main-featured-avatar"
                   alt="Profile picture of {{ user.first_name }} {{ user.last_name }}">
@@ -78,20 +78,21 @@
               </h5>
               {{ user.userprofile.city }}, {{ user.userprofile.country }}
             </div>
-          {% endfor %}
-        {% else %}
-          <div class="large-12 columns">
-            None for this month!
           </div>
-        {% endif %}
-      </div>
-      <div class="row">
-        <div class="large-12 columns top-margined">
-          <div class="markdown">
-            {{ featuredrep.text|markdown }}
+        {% endfor %}
+        <div class="row">
+          <div class="large-12 columns">
+            <div class="markdown">
+              {{ featuredrep.text|markdown }}
+            </div>
           </div>
         </div>
-      </div>
+      {% else %}
+        <div class="large-12 columns">
+          None for this month!
+        </div>
+      {% endif %}
+
       <div class="row">
         <a class="large-12 columns more-posts" href="/featured/">See past featured Reps...</a>
       </div>


### PR DESCRIPTION
In cases when we have more than one Featured Rep, we iterate the html block but we don't add a new row element.

This small refactoring adds a new row element for each Rep with `top-margined` class to add some space in between. Also moved the markdown Featured text inside the if block. No need to evaluate it if no current Featured Rep.