### PR TITLE
[fix bug 1104828] Add pagination and sorting to the ROM page

### DIFF
--- a/remo/base/static/base/css/app-fd4.less
+++ b/remo/base/static/base/css/app-fd4.less
@@ -334,6 +334,39 @@ label.required:after {
     color: #fff;
 }
 
+.pagination {
+    text-align: right;
+    .next {
+        margin-left: 0.5em;
+    }
+    ul.pagination {
+        float: right;
+        a {
+            cursor: pointer;
+        }
+        .current a {
+            color: rgb(51, 51, 51);
+            font-weight: normal;
+            background: transparent;
+            border-bottom: 2px solid rgb(41, 131, 200);
+        }
+        li.unavailable a:focus {
+            text-decoration: none;
+            color: #999;
+            cursor: default;
+        }
+    }
+    #page-select {
+        width: 100px;
+    }
+}
+
+@media only screen and (max-width: @breakSmall) {
+    .pagination {
+        text-align: center;
+    }
+}
+
 /* -----------------------------------------
    Custom Button Styles
 ----------------------------------------- */
@@ -672,6 +705,11 @@ label.required:after {
                 line-height: 1.5;
             }
         }
+    }
+    label {
+        font-size: 13px;
+        display: inline;
+        margin-left: .5em;
     }
 }
 
@@ -1581,15 +1619,6 @@ table .pictogram-button .pict-icon.large {
         width: 95.75%;
         font-family: 'Open Sans Light';
     }
-    #reports-pagination {
-        text-align: right;
-        .next {
-            margin-left: 0.5em;
-        }
-    }
-    #page-select {
-        width: 100px;
-    }
 }
 
 #active-report-form {
@@ -1658,9 +1687,6 @@ table .pictogram-button .pict-icon.large {
             float: none;
             width: 100%;
         }
-        #reports-pagination {
-            text-align: center;
-        }
     }
 
     #active-report-form {
@@ -1671,19 +1697,6 @@ table .pictogram-button .pict-icon.large {
                 float: none;
             }
         }
-    }
-}
-
-#reports-pagination > ul.pagination {
-    float: right;
-    a {
-        cursor: pointer;
-    }
-    .current a {
-        color: rgb(51, 51, 51);
-        font-weight: normal;
-        background: transparent;
-        border-bottom: 2px solid rgb(41, 131, 200);
     }
 }
 
@@ -1743,8 +1756,7 @@ ul.mreports li.unavailable a {
     color: #999;
 }
 
-ul.mreports li.unavailable:hover a,
-ul.pagination li.unavailable a:focus {
+ul.mreports li.unavailable:hover a {
     text-decoration: none;
     color: #999;
     cursor: default;
@@ -1843,15 +1855,6 @@ ul.mreports li.editable a {
         float: right;
         width: 91.75%;
     }
-    #voting-pagination {
-        text-align: right;
-        .next {
-            margin-left: 0.5em;
-        }
-    }
-    #page-select {
-        width: 100px;
-    }
 }
 
 .user-voted:after {
@@ -1867,9 +1870,6 @@ ul.mreports li.editable a {
             float: none;
             width: 100%;
             margin-top: 10px;
-            text-align: center;
-        }
-        #voting-pagination {
             text-align: center;
         }
     }
@@ -1912,19 +1912,6 @@ ul.mreports li.editable a {
     h2 {
         font-size: 24px;
         letter-spacing: -0.25px;
-    }
-}
-
-#voting-pagination > ul.pagination {
-    float: right;
-    a {
-        cursor: pointer;
-    }
-    .current a {
-        color: rgb(51, 51, 51);
-        font-weight: normal;
-        background: transparent;
-        border-bottom: 2px solid rgb(41, 131, 200);
     }
 }
 
@@ -3453,20 +3440,5 @@ table tr.assigned-request:nth-of-type(2n) {
     }
     #action-items-search input {
         width: 94%;
-    }
-    #action-items-pagination {
-        text-align: right;
-        .next {
-            margin-left: 0.5em;
-        }
-    }
-    #action-items-pagination {
-        text-align: right;
-        .next {
-            margin-left: 0.5em;
-        }
-    }
-    #page-select {
-        width: 100px;
     }
 }

--- a/remo/base/templates/includes/pagination.html
+++ b/remo/base/templates/includes/pagination.html
@@ -1,0 +1,27 @@
+<div class="row">
+    <div class="large-12 columns pagination">
+      {% if objects.has_previous() %}
+        <a class="prev" title="Previous page" data-tooltip
+           href="{{ '#'|urlparams(page=objects.previous_page_number(),
+                                  sort_key=sort_key, query=query) }}">
+          &laquo;
+        </a>
+      {% endif %}
+      <label for="page-select">Page: </label>
+      <select id="page-select" autocomplete="off">
+        {% for i in range(1, objects.paginator.num_pages + 1) %}
+          <option {% if i == objects.number %} selected {% endif %}
+                  value="{{ '#'|urlparams(page=i, sort_key=sort_key, query=query) }}">
+            {{ i }}
+          </option>
+        {% endfor %}
+      </select>
+      {% if objects.has_next() %}
+        <a class="next" title="Next page" data-tooltip
+           href="{{ '#'|urlparams(page=objects.next_page_number(),
+                                  sort_key=sort_key, query=query) }}">
+          &raquo;
+        </a>
+      {% endif %}
+    </div>
+</div>

--- a/remo/dashboard/templates/list_action_items.html
+++ b/remo/dashboard/templates/list_action_items.html
@@ -89,7 +89,7 @@
             </tr>
           </thead>
           <tbody>
-            {% for action_item in actions.object_list %}
+            {% for action_item in objects %}
               <tr>
                 <td>
                   <a href="{{ action_item.get_absolute_url() }}">{{ action_item }}</a>
@@ -112,33 +112,8 @@
     </div>
 
     <!-- Paginator -->
-    <div class="row">
-      <div class="large-12 columns" id="action-items-pagination">
-        {% if actions.has_previous() %}
-          <a class="prev" title="Previous page" data-tooltip
-             href="{{ '#'|urlparams(page=actions.previous_page_number(),
-                                    sort_key=sort_key, query=query) }}">
-            &laquo;
-          </a>
-        {% endif %}
-        <label for="page-select">Page: </label>
-        <select id="page-select" autocomplete="off">
-          {% for i in range(1, actions.paginator.num_pages + 1) %}
-            <option {% if i == actions.number %} selected {% endif %}
-                    value="{{ '#'|urlparams(page=i, sort_key=sort_key, query=query) }}">
-              {{ i }}
-            </option>
-          {% endfor %}
-        </select>
-        {% if actions.has_next() %}
-          <a class="next" title="Next page" data-tooltip
-             href="{{ '#'|urlparams(page=actions.next_page_number(),
-                                    sort_key=sort_key, query=query) }}">
-            &raquo;
-          </a>
-        {% endif %}
-      </div>
-    </div>
+    {% include "includes/pagination.html" %}
+
   {% endif %}
 
   <div class="row">

--- a/remo/dashboard/tests/test_views.py
+++ b/remo/dashboard/tests/test_views.py
@@ -228,5 +228,5 @@ class ListActionItemsTests(RemoTestCase):
         self.assertTemplateUsed(response, 'list_action_items.html')
         eq_(response.context['pageheader'], 'My Action Items')
         eq_(response.status_code, 200)
-        eq_(set(response.context['actions'].object_list),
+        eq_(set(response.context['objects'].object_list),
             set([item]))

--- a/remo/dashboard/views.py
+++ b/remo/dashboard/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import User
 from django.core.paginator import EmptyPage, InvalidPage, Paginator
@@ -27,7 +28,6 @@ LIST_ACTION_ITEMS_VALID_SORTS = {
     'action_item_priority_asc': 'priority',
     'action_item_date_desc': '-due_date',
     'action_item_date_asc': 'due_date'}
-LIST_ACTION_ITEMS_PER_PAGE = 25
 
 
 def dashboard_mozillians(request, user):
@@ -248,7 +248,7 @@ def list_action_items(request):
     sort_by = LIST_ACTION_ITEMS_VALID_SORTS[sort_key]
     action_items = action_items.order_by(*sort_by.split(','))
 
-    paginator = Paginator(action_items, LIST_ACTION_ITEMS_PER_PAGE)
+    paginator = Paginator(action_items, settings.ITEMS_PER_PAGE)
 
     # Make sure page request is an int. If not, deliver first page.
     try:
@@ -263,7 +263,7 @@ def list_action_items(request):
         actions = paginator.page(paginator.num_pages)
 
     return render(request, 'list_action_items.html',
-                  {'actions': actions,
+                  {'objects': actions,
                    'number_of_action_items': number_of_action_items,
                    'sort_key': sort_key,
                    'pageheader': pageheader,

--- a/remo/featuredrep/models.py
+++ b/remo/featuredrep/models.py
@@ -22,7 +22,7 @@ class FeaturedRep(models.Model):
     users = models.ManyToManyField(User, related_name='featuredrep_users')
 
     class Meta:
-        ordering = ['-updated_on']
+        ordering = ['-created_on']
         get_latest_by = 'updated_on'
         permissions = (('can_edit_featured', 'Can edit featured reps'),
                        ('can_delete_featured', 'Can delete featured reps'))

--- a/remo/featuredrep/static/featuredrep/js/featuredrep.js
+++ b/remo/featuredrep/static/featuredrep/js/featuredrep.js
@@ -3,5 +3,6 @@ $(document).ready(function () {
         e.preventDefault();
         $(this).closest('form').submit();
     });
+    paginatorSelector();
 });
 

--- a/remo/featuredrep/templates/featuredrep_list.html
+++ b/remo/featuredrep/templates/featuredrep_list.html
@@ -54,7 +54,7 @@
           </tr>
         </thead>
         <tbody>
-          {% for feature in featured %}
+          {% for feature in objects %}
           <tr>
             <td>
               {% for user in feature.users.all() %}
@@ -103,6 +103,9 @@
       </table>
     </div>
   </div>
+
+  <!-- Paginator -->
+  {% include "includes/pagination.html" %}
 </main>
 {% endblock %}
 

--- a/remo/reports/templates/list_ng_reports.html
+++ b/remo/reports/templates/list_ng_reports.html
@@ -107,7 +107,7 @@
             </tr>
           </thead>
           <tbody>
-            {% for report in reports.object_list %}
+            {% for report in objects %}
               <tr>
                 <td>
                   <a href="{{ url('list_ng_reports_rep',
@@ -173,33 +173,9 @@
       </div>
     </div>
 
-    <div class="row">
-      <div class="large-12 columns" id="reports-pagination">
-        {% if reports.has_previous() %}
-          <a class="prev" title="Previous page" data-tooltip
-             href="{{ '#'|urlparams(page=reports.previous_page_number(),
-                                    sort_key=sort_key, query=query) }}">
-            &laquo;
-          </a>
-        {% endif %}
-        <label for="page-select">Page: </label>
-        <select id="page-select" autocomplete="off">
-          {% for i in range(1, reports.paginator.num_pages + 1) %}
-            <option {% if i == reports.number %} selected {% endif %}
-                    value="{{ '#'|urlparams(page=i, sort_key=sort_key, query=query) }}">
-              {{ i }}
-            </option>
-          {% endfor %}
-        </select>
-        {% if reports.has_next() %}
-          <a class="next" title="Next page" data-tooltip
-             href="{{ '#'|urlparams(page=reports.next_page_number(),
-                                    sort_key=sort_key, query=query) }}">
-            &raquo;
-          </a>
-        {% endif %}
-      </div>
-    </div>
+    <!-- Paginator -->
+    {% include "includes/pagination.html" %}
+
   {% endif %}
 
   <div class="row">

--- a/remo/reports/tests/test_views.py
+++ b/remo/reports/tests/test_views.py
@@ -311,7 +311,7 @@ class ListNGReportTests(RemoTestCase):
         self.assertTemplateUsed(response, 'list_ng_reports.html')
         eq_(response.context['pageheader'], 'Activities for Reps')
         eq_(response.status_code, 200)
-        eq_(set(response.context['reports'].object_list),
+        eq_(set(response.context['objects'].object_list),
             set([report]))
 
     def test_list_rep(self):
@@ -324,7 +324,7 @@ class ListNGReportTests(RemoTestCase):
         response = self.get(url=reverse('list_ng_reports_rep',
                                         kwargs={'rep': name}), user=user)
         eq_(response.context['pageheader'], 'Activities for Foo Bar')
-        eq_(set(response.context['reports'].object_list),
+        eq_(set(response.context['objects'].object_list),
             set([report]), 'Other Rep reports are listed')
 
     def test_list_mentor(self):
@@ -340,7 +340,7 @@ class ListNGReportTests(RemoTestCase):
                                         kwargs={'mentor': name}), user=mentor)
         msg = 'Activities for Reps mentored by Foo Bar'
         eq_(response.context['pageheader'], msg)
-        eq_(set(response.context['reports'].object_list),
+        eq_(set(response.context['objects'].object_list),
             set([report_1, report_2]), 'Other Mentor reports are listed')
 
     def test_get_invalid_order(self):
@@ -353,7 +353,7 @@ class ListNGReportTests(RemoTestCase):
         report = NGReportFactory.create()
         NGReportFactory.create(report_date=datetime.date(2999, 1, 1))
         response = self.get(reverse('list_ng_reports'))
-        eq_(set(response.context['reports'].object_list),
+        eq_(set(response.context['objects'].object_list),
             set([report]))
 
     def test_functional_area_list(self):
@@ -364,7 +364,7 @@ class ListNGReportTests(RemoTestCase):
         url = reverse('list_ng_reports_functional_area',
                       kwargs={'functional_area_slug': functional_area_1.slug})
         response = self.get(url=url)
-        eq_(set(response.context['reports'].object_list), set([report]))
+        eq_(set(response.context['objects'].object_list), set([report]))
 
     def test_rep_functional_area_list(self):
         user = UserFactory.create(groups=['Rep'])
@@ -376,7 +376,7 @@ class ListNGReportTests(RemoTestCase):
                       kwargs={'functional_area_slug': functional_area.slug,
                               'rep': user.userprofile.display_name})
         response = self.get(url=url)
-        eq_(set(response.context['reports'].object_list), set([report]))
+        eq_(set(response.context['objects'].object_list), set([report]))
 
     def test_mentor_functional_area_list(self):
         mentor = UserFactory.create(groups=['Mentor'])
@@ -388,7 +388,7 @@ class ListNGReportTests(RemoTestCase):
                       kwargs={'functional_area_slug': functional_area.slug,
                               'mentor': mentor.userprofile.display_name})
         response = self.get(url=url)
-        eq_(set(response.context['reports'].object_list), set([report]))
+        eq_(set(response.context['objects'].object_list), set([report]))
 
 
 class LegacyReportingTests(RemoTestCase):

--- a/remo/reports/views.py
+++ b/remo/reports/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import User
 from django.core.paginator import EmptyPage, InvalidPage, Paginator
@@ -31,7 +32,6 @@ LIST_NG_REPORTS_VALID_SORTS = {
     'activity_asc': 'activity__name',
     'report_date_desc': '-report_date',
     'report_date_asc': 'report_date'}
-LIST_REPORTS_NUMBER_OF_REPORTS_PER_PAGE = 25
 
 
 @never_cache
@@ -241,7 +241,7 @@ def list_ng_reports(request, mentor=None, rep=None, functional_area_slug=None):
     sort_by = LIST_NG_REPORTS_VALID_SORTS[sort_key]
     report_list = report_list.order_by(*sort_by.split(','))
 
-    paginator = Paginator(report_list, LIST_REPORTS_NUMBER_OF_REPORTS_PER_PAGE)
+    paginator = Paginator(report_list, settings.ITEMS_PER_PAGE)
 
     # Make sure page request is an int. If not, deliver first page.
     try:
@@ -256,7 +256,7 @@ def list_ng_reports(request, mentor=None, rep=None, functional_area_slug=None):
         reports = paginator.page(paginator.num_pages)
 
     return render(request, 'list_ng_reports.html',
-                  {'reports': reports,
+                  {'objects': reports,
                    'number_of_reports': number_of_reports,
                    'sort_key': sort_key,
                    'pageheader': pageheader,

--- a/remo/voting/templates/list_votings.html
+++ b/remo/voting/templates/list_votings.html
@@ -16,7 +16,7 @@
     {% endif %}
   </div>
 
-  {% macro display_polls(polls, show_pagination) -%}
+  {% macro display_polls(objects, show_pagination) -%}
     <div class="large-12 columns">
       <table class="dashboard-table responsive">
         <thead>
@@ -30,7 +30,7 @@
           </tr>
         </thead>
         <tbody>
-          {% for poll in polls %}
+          {% for poll in objects %}
             <tr>
               <td>
                 <a href="{{ url('voting_view_voting', slug=poll.slug) }}">
@@ -60,31 +60,8 @@
         </tbody>
       </table>
       {% if show_pagination %}
-        <div class="row">
-          <div class="large-12 columns" id="voting-pagination">
-            {% if polls.has_previous() %}
-              <a class="prev" title="Previous Page" data-tooltip
-                 href="{{ '#'|urlparams(page=polls.previous_page_number()) }}">
-                &laquo;
-              </a>
-            {% endif %}
-            <label for="page-select">Page: </label>
-            <select id="page-select" autocomplete="off">
-              {% for i in range(1, polls.paginator.num_pages + 1) %}
-                <option {% if i == polls.number %} selected {% endif %}
-                        value="{{ '#'|urlparams(page=i) }}">
-                  {{ i }}
-                </option>
-              {% endfor %}
-            </select>
-            {% if polls.has_next() %}
-              <a class="next" title="Next Page" data-tooltip
-                 href="{{ '#'|urlparams(page=polls.next_page_number()) }}">
-                &raquo;
-              </a>
-            {% endif %}
-          </div>
-        </div>
+        <!-- Paginator -->
+        {% include "includes/pagination.html" %}
       {% endif %}
     </div>
   {%- endmacro%}


### PR DESCRIPTION
* Added pagination every 15 objects
* Until we have a more sane way to determine when a Rep was featured, it makes sense to sort them based on the `created_on` date.