### PR TITLE
Fix Alumni missing pagination

### DIFF
--- a/remo/profiles/templates/profiles_list_alumni.html
+++ b/remo/profiles/templates/profiles_list_alumni.html
@@ -58,10 +58,9 @@
             {% endfor %}
           </tbody>
         </table>
-        {% if show_pagination %}
-          <!-- Paginator -->
-          {% include "includes/pagination.html" %}
-        {% endif %}
+
+        <!-- Paginator -->
+        {% include "includes/pagination.html" %}
       </div>
     {% else %}
       <div class="large-12 columns profiles-no-results">


### PR DESCRIPTION
This was left there due to the macro we initially had on the template. We missed it when we removed it.