### PR TITLE
[Fix bug 1144188] Expose API endpoint for activities KPI.

### DIFF
--- a/remo/api/serializers.py
+++ b/remo/api/serializers.py
@@ -1,0 +1,11 @@
+from rest_framework import serializers
+
+
+class BaseKPIserializer(serializers.Serializer):
+    """Serializer for the KPI data."""
+    total = serializers.IntegerField()
+    quarter_total = serializers.IntegerField()
+    quarter_growth_percentage = serializers.FloatField()
+    week_total = serializers.IntegerField()
+    week_growth_percentage = serializers.FloatField()
+    total_per_week = serializers.ListField()

--- a/remo/api/urls.py
+++ b/remo/api/urls.py
@@ -7,7 +7,7 @@ from remo.events.api.api_v1 import EventResource
 from remo.events.api.views import EventsKPIView, EventsViewSet
 from remo.profiles.api.api_v1 import RepResource
 from remo.profiles.api.views import UserProfileViewSet
-from remo.reports.api.views import ActivitiesViewSet
+from remo.reports.api.views import ActivitiesKPIView, ActivitiesViewSet
 
 
 # Legacy non-public API
@@ -25,5 +25,7 @@ urlpatterns = patterns(
     '',
     url(r'', include(v1_api.urls)),
     url(r'^beta/', include(router.urls), name='v1root'),
-    url(r'^kpi/events/', EventsKPIView.as_view(), name='kpi-events')
+    url(r'^kpi/events/', EventsKPIView.as_view(), name='kpi-events'),
+    url(r'^kpi/activities/', ActivitiesKPIView.as_view(),
+        name='kpi-activities'),
 )

--- a/remo/base/tests/test_base_utils.py
+++ b/remo/base/tests/test_base_utils.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+from mock import patch
+
+from nose.tools import eq_
+
+from remo.base.tests import RemoTestCase
+from remo.base.utils import get_quarter
+
+
+class GetQuarterTest(RemoTestCase):
+    def get_quarter_date(self):
+        d = datetime(2015, 8, 15)
+        result = get_quarter(d)
+        eq_(result[0], 3)
+        eq_(result[1], datetime(2015, 7, 1))
+
+    @patch('remo.base.utils.timezone.now')
+    def get_quarter_none(self, now_mock):
+        now_mock.return_value = datetime(2015, 6, 15)
+        result = get_quarter()
+        eq_(result[0], 2)
+        eq_(result[1], datetime(2015, 6, 1))

--- a/remo/base/utils.py
+++ b/remo/base/utils.py
@@ -1,5 +1,6 @@
 import calendar
 import datetime
+import math
 
 from django.conf import settings
 from django.contrib.auth.management import create_permissions
@@ -150,3 +151,15 @@ def daterange(start_date, end_date):
     """Generator with a range of dates given a starting and ending point."""
     for i in range((end_date - start_date).days + 1):
         yield start_date + datetime.timedelta(i)
+
+
+def get_quarter(date=None):
+    """Return the quarter for this date and datetime of Q's start."""
+    if not date:
+        date = timezone.now()
+
+    quarter = int(math.ceil(date.month/3.0))
+    first_month_of_quarter = 1 + 3*(quarter-1)
+    quarter_start = datetime.datetime(date.year, first_month_of_quarter, 1)
+
+    return (quarter, quarter_start)

--- a/remo/events/api/serializers.py
+++ b/remo/events/api/serializers.py
@@ -34,13 +34,3 @@ class EventDetailedSerializer(serializers.HyperlinkedModelSerializer):
         in ReMo portal.
         """
         return absolutify(obj.get_absolute_url())
-
-
-class EventsKPISerializer(serializers.Serializer):
-    """Serializer for the Events KPI data"""
-    total = serializers.IntegerField()
-    total_quarter = serializers.IntegerField()
-    percentage_quarter = serializers.FloatField()
-    total_week = serializers.IntegerField()
-    percentage_week = serializers.FloatField()
-    total_per_week = serializers.ListField()

--- a/remo/events/api/views.py
+++ b/remo/events/api/views.py
@@ -1,4 +1,3 @@
-import math
 from collections import namedtuple
 from datetime import datetime, timedelta
 
@@ -10,8 +9,10 @@ from rest_framework.views import APIView
 from rest_framework.viewsets import ReadOnlyModelViewSet
 from rest_framework.response import Response
 
+from remo.api.serializers import BaseKPIserializer
+from remo.base.utils import get_quarter
 from remo.events.api.serializers import (EventDetailedSerializer,
-                                         EventSerializer, EventsKPISerializer)
+                                         EventSerializer)
 from remo.events.models import Event
 
 
@@ -32,9 +33,13 @@ class EventsViewSet(ReadOnlyModelViewSet):
 
 
 class EventsKPIFilter(django_filters.FilterSet):
+    """Filter for events KPI endpoint."""
+    category = django_filters.CharFilter(name='categories__name')
+    initiative = django_filters.CharFilter(name='campaign__name')
+
     class Meta:
         model = Event
-        fields = ['categories__name', 'campaign__name', 'country']
+        fields = ['country', 'category', 'initiative']
 
 
 class EventsKPIView(APIView):
@@ -42,37 +47,47 @@ class EventsKPIView(APIView):
     def get(self, request):
         """Returns serialized data for Events KPI"""
 
-        queryset = Event.objects.filter(start__lte=now())
-        events = EventsKPIFilter(request.GET, queryset=queryset)
-        weeks = int(request.QUERY_PARAMS.get('weeks', KPI_WEEKS))
+        qs = Event.objects.filter(start__lte=now())
+        events = EventsKPIFilter(request.query_params, queryset=qs)
+        weeks = int(request.query_params.get('weeks', KPI_WEEKS))
 
-        # Total calculations
+        # Total number of events to day
         total = events.qs.count()
 
         # Quarter calculations
-        current_quarter = int(math.ceil(now().month/3.0))
-        current_quarter_start = datetime(now().year, current_quarter, 1)
+        current_quarter_start = get_quarter()[1]
+
+        # Total number of events for current quarter
         quarter_total = events.qs.filter(
             start__gte=current_quarter_start).count()
 
-        # Total events until start of quarter
-        quarter_s_total = events.qs.filter(
+        # Total number of events until start of quarter
+        events_bfr_quarter = events.qs.filter(
             start__lte=current_quarter_start).count()
 
         try:
-            percent_quarter = (total-quarter_s_total)/float(quarter_s_total)
+            # Percentage change of events since start of quarter
+            diff = total - events_bfr_quarter
+            percent_quarter = diff/float(events_bfr_quarter)
         except ZeroDivisionError:
             percent_quarter = 0
 
         # Week calculations
-        current_week_start = now() - timedelta(days=now().weekday())
+        today = datetime.combine(now().date(), datetime.min.time())
+        current_week_start = today - timedelta(days=now().weekday())
         prev_week_start = current_week_start - timedelta(weeks=1)
+
+        # Total number of events this week
         week_total = events.qs.filter(start__gte=current_week_start).count()
         query_range = [prev_week_start, current_week_start]
+
+        # Total number of events for previous week
         prev_week_total = events.qs.filter(start__range=query_range).count()
 
         try:
-            percent_week = (week_total-prev_week_total)/float(prev_week_total)
+            # Percentage change of events compared with previous week
+            diff = week_total - prev_week_total
+            percent_week = diff/float(prev_week_total)
         except ZeroDivisionError:
             percent_week = 0
 
@@ -81,19 +96,21 @@ class EventsKPIView(APIView):
         for i in range(weeks):
             start = current_week_start - timedelta(weeks=i)
             end = start + timedelta(weeks=1)
+
+            # Total number of events (per week) for previous weeks
             count = events.qs.filter(start__range=[start, end]).count()
             weekly_count.append({'week': weeks-i, 'events': count})
 
         kwargs = {
             'total': total,
-            'total_quarter': quarter_total,
-            'percentage_quarter': percent_quarter*100,
-            'total_week': week_total,
-            'percentage_week': percent_week*100,
+            'quarter_total': quarter_total,
+            'quarter_growth_percentage': percent_quarter*100,
+            'week_total': week_total,
+            'week_growth_percentage': percent_week*100,
             'total_per_week': weekly_count
         }
 
         kpi = namedtuple('EventsKPI', kwargs.keys())(*kwargs.values())
-        serializer = EventsKPISerializer(kpi)
+        serializer = BaseKPIserializer(kpi)
 
         return Response(serializer.data)

--- a/remo/events/tests/test_api.py
+++ b/remo/events/tests/test_api.py
@@ -80,7 +80,7 @@ class TestEventsKPIView(RemoTestCase):
     def test_total(self):
         EventFactory.create()
         request = self.factory.get(self.url)
-        request.QUERY_PARAMS = dict()
+        request.query_params = dict()
         response = EventsKPIView().get(request)
         eq_(response.data['total'], 1)
 
@@ -104,11 +104,11 @@ class TestEventsKPIView(RemoTestCase):
         EventFactory.create(start=start, end=end)
 
         request = self.factory.get(self.url)
-        request.QUERY_PARAMS = dict()
+        request.query_params = dict()
 
         response = EventsKPIView().get(request)
-        eq_(response.data['total_quarter'], 1)
-        eq_(response.data['percentage_quarter'], (3-2)*100/2.0)
+        eq_(response.data['quarter_total'], 1)
+        eq_(response.data['quarter_growth_percentage'], (3-2)*100/2.0)
 
     @patch('remo.events.api.views.now')
     def test_current_week(self, mock_now):
@@ -130,11 +130,11 @@ class TestEventsKPIView(RemoTestCase):
         EventFactory.create(start=start, end=end)
 
         request = self.factory.get(self.url)
-        request.QUERY_PARAMS = dict()
+        request.query_params = dict()
 
         response = EventsKPIView().get(request)
-        eq_(response.data['total_week'], 1)
-        eq_(response.data['percentage_week'], (1-2)*100/2.0)
+        eq_(response.data['week_total'], 1)
+        eq_(response.data['week_growth_percentage'], (1-2)*100/2.0)
 
     @patch('remo.events.api.views.now')
     def test_weeks(self, mock_now):
@@ -166,11 +166,11 @@ class TestEventsKPIView(RemoTestCase):
         EventFactory.create(start=start, end=end)
 
         request = self.factory.get(self.url)
-        request.QUERY_PARAMS = {'weeks': 4}
+        request.query_params = {'weeks': 4}
 
         response = EventsKPIView().get(request)
-        eq_(response.data['total_week'], 3)
-        eq_(response.data['percentage_week'], (3-2)*100/2.0)
+        eq_(response.data['week_total'], 3)
+        eq_(response.data['week_growth_percentage'], (3-2)*100/2.0)
         total_per_week = [
             {'week': 1, 'events': 1},
             {'week': 2, 'events': 4},

--- a/remo/reports/api/views.py
+++ b/remo/reports/api/views.py
@@ -1,11 +1,22 @@
-from django.shortcuts import get_object_or_404
+from collections import namedtuple
+from datetime import datetime, timedelta
 
+from django.shortcuts import get_object_or_404
+from django.utils.timezone import now
+
+import django_filters
+from rest_framework.views import APIView
 from rest_framework.viewsets import ReadOnlyModelViewSet
 from rest_framework.response import Response
 
+from remo.api.serializers import BaseKPIserializer
+from remo.base.utils import get_quarter
 from remo.reports.api.serializers import (ActivitiesDetailedSerializer,
                                           ActivitiesSerializer)
 from remo.reports.models import NGReport
+
+
+KPI_WEEKS = 6
 
 
 class ActivitiesViewSet(ReadOnlyModelViewSet):
@@ -18,4 +29,90 @@ class ActivitiesViewSet(ReadOnlyModelViewSet):
         report = get_object_or_404(self.get_queryset(), pk=pk)
         serializer = ActivitiesDetailedSerializer(report,
                                                   context={'request': request})
+        return Response(serializer.data)
+
+
+class ActivitiesKPIFilter(django_filters.FilterSet):
+    """Filter for activities KPI endpoint."""
+    category = django_filters.CharFilter(name='functional_areas__name')
+    initiative = django_filters.CharFilter(name='campaign__name')
+
+    class Meta:
+        model = NGReport
+        fields = ['country', 'category', 'initiative']
+
+
+class ActivitiesKPIView(APIView):
+
+    def get(self, request):
+        """Returns serialized data for Activities KPI"""
+
+        qs = NGReport.objects.filter(report_date__lte=now())
+        activities = ActivitiesKPIFilter(request.query_params, queryset=qs)
+        weeks = int(request.query_params.get('weeks', KPI_WEEKS))
+
+        # Total number of activities to day
+        total = activities.qs.count()
+
+        # Quarter calculations
+        current_quarter_start = get_quarter()[1]
+
+        # Total number of activities for current quarter
+        quarter_total = activities.qs.filter(
+            report_date__gte=current_quarter_start).count()
+
+        # Total number of activities until start of quarter
+        activities_bfr_quarter = activities.qs.filter(
+            report_date__lte=current_quarter_start).count()
+
+        try:
+            # Percentage change of activities since start of quarter
+            diff = total - activities_bfr_quarter
+            percent_quarter = diff/float(activities_bfr_quarter)
+        except ZeroDivisionError:
+            percent_quarter = 0
+
+        # Week calculations
+        today = datetime.combine(now().date(), datetime.min.time())
+        current_week_start = today - timedelta(days=now().weekday())
+        prev_week_start = current_week_start - timedelta(weeks=1)
+
+        # Total number of activities this week
+        week_total = activities.qs.filter(
+            report_date__gte=current_week_start).count()
+        query_range = [prev_week_start, current_week_start]
+
+        # Total number of activities for previous week
+        prev_week_total = activities.qs.filter(
+            report_date__range=query_range).count()
+
+        try:
+            # Percentage change of activities compared with previous week
+            diff = week_total-prev_week_total
+            percent_week = diff/float(prev_week_total)
+        except ZeroDivisionError:
+            percent_week = 0
+
+        weekly_count = []
+        for i in range(weeks):
+            start = current_week_start - timedelta(weeks=i)
+            end = start + timedelta(weeks=1)
+
+            # Total number of activities (per week) for previous weeks
+            count = activities.qs.filter(
+                report_date__range=[start, end]).count()
+            weekly_count.append({'week': weeks-i, 'activities': count})
+
+        kwargs = {
+            'total': total,
+            'quarter_total': quarter_total,
+            'quarter_growth_percentage': percent_quarter*100,
+            'week_total': week_total,
+            'week_growth_percentage': percent_week*100,
+            'total_per_week': weekly_count
+        }
+
+        kpi = namedtuple('ActivitiesKPI', kwargs.keys())(*kwargs.values())
+        serializer = BaseKPIserializer(kpi)
+
         return Response(serializer.data)


### PR DESCRIPTION
* Add APIView with the stats required for the activities KPI
* Enable filtering on `country`, `functional_areas__name`, `campaign__name`
* Use a generic KPI serializer since output is similar to all endpoints