### PR TITLE
Fix patching `django.utils.timezone.now` on kpi tests.

### DIFF
--- a/remo/events/tests/test_api.py
+++ b/remo/events/tests/test_api.py
@@ -85,8 +85,11 @@ class TestEventsKPIView(RemoTestCase):
         eq_(response.data['total'], 1)
 
     @patch('remo.events.api.views.now')
-    def test_quarter(self, mock_now):
-        mock_now.return_value = datetime(2015, 3, 1)
+    @patch('remo.base.utils.timezone.now')
+    def test_quarter(self, mock_api_now, mock_utils_now):
+        now_return_value = datetime(2015, 3, 1)
+        mock_api_now.return_value = now_return_value
+        mock_utils_now.return_value = now_return_value
 
         # Previous quarter
         start = datetime(2014, 12, 5)
@@ -111,8 +114,11 @@ class TestEventsKPIView(RemoTestCase):
         eq_(response.data['quarter_growth_percentage'], (3-2)*100/2.0)
 
     @patch('remo.events.api.views.now')
-    def test_current_week(self, mock_now):
-        mock_now.return_value = datetime(2015, 3, 1)
+    @patch('remo.base.utils.timezone.now')
+    def test_current_week(self, mock_api_now, mock_utils_now):
+        now_return_value = datetime(2015, 3, 1)
+        mock_api_now.return_value = now_return_value
+        mock_utils_now.return_value = now_return_value
 
         # Current week
         start = datetime(2015, 2, 25)
@@ -137,8 +143,11 @@ class TestEventsKPIView(RemoTestCase):
         eq_(response.data['week_growth_percentage'], (1-2)*100/2.0)
 
     @patch('remo.events.api.views.now')
-    def test_weeks(self, mock_now):
-        mock_now.return_value = datetime(2015, 3, 1)
+    @patch('remo.base.utils.timezone.now')
+    def test_weeks(self, mock_api_now, mock_utils_now):
+        now_return_value = datetime(2015, 3, 1)
+        mock_api_now.return_value = now_return_value
+        mock_utils_now.return_value = now_return_value
 
         # Current week
         start = datetime(2015, 2, 25)

--- a/remo/reports/tests/test_api.py
+++ b/remo/reports/tests/test_api.py
@@ -88,8 +88,11 @@ class TestActivitiesKPIView(RemoTestCase):
         eq_(response.data['total'], 1)
 
     @patch('remo.reports.api.views.now')
-    def test_quarter(self, mock_now):
-        mock_now.return_value = datetime(2015, 3, 1)
+    @patch('remo.base.utils.timezone.now')
+    def test_quarter(self, mock_api_now, mock_utils_now):
+        now_return_value = datetime(2015, 3, 1)
+        mock_api_now.return_value = now_return_value
+        mock_utils_now.return_value = now_return_value
 
         # Previous quarter
         report_date = date(2014, 12, 5)
@@ -111,8 +114,11 @@ class TestActivitiesKPIView(RemoTestCase):
         eq_(response.data['quarter_growth_percentage'], (3-2)*100/2.0)
 
     @patch('remo.reports.api.views.now')
-    def test_current_week(self, mock_now):
-        mock_now.return_value = datetime(2015, 3, 1)
+    @patch('remo.base.utils.timezone.now')
+    def test_current_week(self, mock_api_now, mock_utils_now):
+        now_return_value = datetime(2015, 3, 1)
+        mock_api_now.return_value = now_return_value
+        mock_utils_now.return_value = now_return_value
 
         # Current week
         report_date = date(2015, 2, 25)
@@ -134,8 +140,11 @@ class TestActivitiesKPIView(RemoTestCase):
         eq_(response.data['week_growth_percentage'], (1-2)*100/2.0)
 
     @patch('remo.reports.api.views.now')
-    def test_weeks(self, mock_now):
-        mock_now.return_value = datetime(2015, 3, 1)
+    @patch('remo.base.utils.timezone.now')
+    def test_weeks(self, mock_api_now, mock_utils_now):
+        now_return_value = datetime(2015, 3, 1)
+        mock_api_now.return_value = now_return_value
+        mock_utils_now.return_value = now_return_value
 
         # Current week
         report_date = date(2015, 2, 26)


### PR DESCRIPTION
Tests where failing because we only patched ``now`` in ``api/views.py`` namespace and not in ``base/utils.py``.