### PR TITLE
Allow empty mentor fields in API v1.

### DIFF
--- a/remo/profiles/api/api_v1.py
+++ b/remo/profiles/api/api_v1.py
@@ -47,7 +47,7 @@ class ProfileResource(ModelResource):
                                           attribute='functional_areas',
                                           full=True, null=True)
     mentor = fields.ToOneField('remo.profiles.api.api_v1.RepResource',
-                               attribute='mentor')
+                               attribute='mentor', null=True)
     last_report_date = fields.DateField()
 
     class Meta:


### PR DESCRIPTION
Now with the Alumni group a few profiles are without a mentor. For example right now the /people in the dev instance is broken due to an empty mentor field.