### PR TITLE
 [fix bug 1216035] fix broken etherpad link on reps portal

### DIFF
--- a/remo/settings/base.py
+++ b/remo/settings/base.py
@@ -110,7 +110,7 @@ ENGAGE_ROBOTS = True
 TIME_ZONE = 'UTC'
 USE_TZ = True
 
-ETHERPAD_URL = 'https://public.etherpad-mozilla.org/'
+ETHERPAD_URL = 'https://public.etherpad-mozilla.org/p/'
 ETHERPAD_PREFIX = 'remo-'
 
 CONTRIBUTE_URL = ('http://www.mozilla.org/contribute/'


### PR DESCRIPTION
changed link from public.etherpad-mozilla.org/padname  to public.etherpad-mozilla.org/p/padname