### PR TITLE
Unicode title for the event metrics mail reminders please.

### DIFF
--- a/remo/events/tasks.py
+++ b/remo/events/tasks.py
@@ -31,7 +31,7 @@ def notify_event_owners_to_input_metrics():
 
         action_item = ActionItem.objects.filter(content_type=event_model, object_id=event.id)
         if not action_item.exists():
-            subject = '[Reminder] Please add the actual metrics for event {0}'.format(event.name)
+            subject = u'[Reminder] Please add the actual metrics for event {0}'.format(event.name)
             template = 'email/event_creator_notification_to_input_metrics.jinja'
             data = {'event': event}
             send_remo_mail.delay(subject=subject, email_template=template,


### PR DESCRIPTION
This will fix a couple celery tracebacks when the title of an event has unicode chars. @johngian r?