### PR TITLE
[Bug 1313018] Save also the nominator of the Rep

### DIFF
--- a/remo/profiles/forms.py
+++ b/remo/profiles/forms.py
@@ -298,8 +298,10 @@ class RotmNomineeForm(happyforms.Form):
             raise ValidationError('You cannot nominate a non Rep user.')
         return cdata
 
-    def save(self, *args, **kwargs):
+    def save(self, nominated_by, *args, **kwargs):
         if (self.instance and not self.instance.is_rotm_nominee and
+                nominated_by != self.instance.user and
                 self.cleaned_data['is_rotm_nominee']):
             self.instance.is_rotm_nominee = True
+            self.instance.rotm_nominated_by = nominated_by
             self.instance.save()

--- a/remo/profiles/migrations/0004_userprofile_rotm_nominated_by.py
+++ b/remo/profiles/migrations/0004_userprofile_rotm_nominated_by.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+import remo.profiles.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('profiles', '0003_auto_20160921_1608'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='userprofile',
+            name='rotm_nominated_by',
+            field=models.ForeignKey(related_name='rotm_nominations', on_delete=django.db.models.deletion.SET_NULL, validators=[remo.profiles.models._validate_mentor], to=settings.AUTH_USER_MODEL, blank=True, null=True),
+        ),
+    ]

--- a/remo/profiles/models.py
+++ b/remo/profiles/models.py
@@ -183,6 +183,10 @@ class UserProfile(caching.base.CachingMixin, models.Model):
                                               null=True, editable=False,
                                               default='')
     is_rotm_nominee = models.BooleanField(default=False)
+    rotm_nominated_by = models.ForeignKey(User, null=True, blank=True,
+                                          related_name='rotm_nominations',
+                                          validators=[_validate_mentor],
+                                          on_delete=models.SET_NULL)
     action_items = generic.GenericRelation('dashboard.ActionItem')
 
     objects = caching.base.CachingManager()

--- a/remo/profiles/tasks.py
+++ b/remo/profiles/tasks.py
@@ -83,6 +83,7 @@ def reset_rotm_nominees():
         nominees = UserProfile.objects.filter(is_rotm_nominee=True)
         for nominee in nominees:
             nominee.is_rotm_nominee = False
+            nominee.rotm_nominated_by = None
             nominee.save()
 
 

--- a/remo/profiles/templates/profiles_view.jinja
+++ b/remo/profiles/templates/profiles_view.jinja
@@ -256,8 +256,9 @@ Mozilla Reps - Profile of {{ user_profile.display_name }}
                 {% endfor %}
               </h6>
             {% endif %}
-            {% if (is_nomination_period and user_is_mentor(request_user) and
-                   user_is_rep(user_profile.user)) or waffle.switch('enable_rotm_tasks') %}
+            {% if ((is_nomination_period or waffle.switch('enable_rotm_tasks')) and
+                    user_is_mentor(request_user) and user_is_rep(user_profile.user) and
+                    request_user != user_profile.user) %}
               <p class="profile-item">
                 <form id="nominate-rotm-form" method="post"
                       actions="{{ url('profiles_view_profile', user_profile.display_name) }}">
@@ -268,7 +269,8 @@ Mozilla Reps - Profile of {{ user_profile.display_name }}
                           {% if user_nominated %}disabled{% endif %}"
                           data-user-nominated="{{ user_nominated }}"
                           title="You can nominate this user the first fifteen days of each month">
-                    {% if user_nominated %}User nominated!{% else %}Nominate for Rep of the month{% endif %}
+                    {% if user_nominated %}User nominated by {{ user_profile.rotm_nominated_by }}!
+                      {% else %}Nominate for Rep of the month{% endif %}
                   </button>
                 </form>
               </p>

--- a/remo/profiles/views.py
+++ b/remo/profiles/views.py
@@ -194,11 +194,11 @@ def view_profile(request, display_name):
             messages.info(request, mark_safe(msg))
 
     if nominee_form.is_valid():
-        if ((is_nomination_period or
-             waffle.switch_is_active('enable_rotm_tasks')) and
-                request.user.groups.filter(name='Mentor').exists()):
-            nominee_form.save()
+        if ((is_nomination_period or waffle.switch_is_active('enable_rotm_tasks')) and
+                request.user.groups.filter(name='Mentor').exists() and request.user != user):
+            nominee_form.save(nominated_by=request.user)
             return redirect('profiles_view_profile', display_name=display_name)
+
         messages.warning(request, ('Only mentors can nominate a mentee.'))
 
     if user_is_alumni:


### PR DESCRIPTION
So this patch will change as following
- Who nominate a user as rep of the month is saved in the database in `rotm_nominated_by` column
- A user would not able to nominate himself for reps of the month

So I have slightly change the logic in the template. There was a little bug in the logic that made the button available for all while the waffle flag `enable_rotm_tasks` is activated.

@akatsoulas r?
