### PR TITLE
Fix migration problem in docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,9 @@ db:
     - MYSQL_USER=remo
     - MYSQL_PASSWORD=remo
     - MYSQL_ROOT_PASSWORD=root
+  entrypoint:
+    - docker-entrypoint.sh
+    - --max_allowed_packet=2M
 memcached:
   image: memcached
 broker:


### PR DESCRIPTION
Running migration made the mysql server gone away in docker. So need
to fix it by extending the maximum allowed package. by default it is 1M. So changing it to 2M will let the migration run smoothly.
@akatsoulas r?
