### PR TITLE
Add code to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,3 +18,4 @@ ENV LANGUAGE en_US.UTF-8
 
 COPY requirements /code/requirements/
 RUN pip install --require-hashes --no-deps -r requirements/dev.txt
+COPY . /code/


### PR DESCRIPTION
Copy code after installing requirements because it means that if there is no changes to packages we only need to pull a 5MB layer (instead of 150MB with packages)