### PR TITLE
Install rabbitmq-server in docker dev.

### DIFF
--- a/docker/dev
+++ b/docker/dev
@@ -7,7 +7,7 @@ CMD ["./bin/run-dev.sh"]
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential libxml2-dev libxslt1-dev libffi-dev python-dev \
-    libmysqlclient-dev mysql-client python-pip node-less locales && \
+    libmysqlclient-dev mysql-client python-pip node-less locales rabbitmq-server && \
     rm -rf /var/lib/apt/lists/*
 
 RUN dpkg-reconfigure locales && locale-gen C.UTF-8 && \


### PR DESCRIPTION
@flamingspaz r?

AMQP is listed as the broker in the env-dist file but we don't have it as a dependency anywhere.