### PR TITLE
[bug 1386383] Login via admin panel raise error

### DIFF
--- a/remo/base/backend.py
+++ b/remo/base/backend.py
@@ -48,3 +48,13 @@ class RemoAuthenticationBackend(OIDCAuthenticationBackend):
             user.save()
             user.groups.add(Group.objects.get(name='Mozillians'))
             return user
+
+    def authenticate(self, **kwargs):
+        """ Override authenticate method in order to combine with other backends.
+        It was fixed with PR #87 and released in version 0.2.0
+        """
+        # TODO: remove this override whenever upgrade `mozilla-django-oidc` to version 0.2.0
+        if not kwargs.get('request'):
+            return None
+
+        return super(RemoAuthenticationBackend, self).authenticate(**kwargs)

--- a/remo/base/middleware.py
+++ b/remo/base/middleware.py
@@ -18,7 +18,8 @@ class RegisterMiddleware(object):
     def process_request(self, request):
         if (request.user.is_authenticated() and not
             request.user.userprofile.registration_complete and not
-                request.user.groups.filter(name='Mozillians').exists()):
+                request.user.groups.filter(name='Mozillians').exists() and not
+                request.user.is_superuser):
             allow_urls = [
                 reverse('oidc_authentication_init'),
                 reverse('oidc_authentication_callback'),

--- a/remo/profiles/models.py
+++ b/remo/profiles/models.py
@@ -377,7 +377,10 @@ def userprofile_set_display_name_pre_save(sender, instance, **kwargs):
         display_name = display_name[:DISPLAY_NAME_MAX_LENGTH]
 
         while True:
-            instance.display_name = display_name
+            # User created with management command can have blank email.
+            # That may result blank display_name.
+            # As display_name can not be blank, add `_` if its blank
+            instance.display_name = display_name or '_'
 
             try:
                 instance.validate_unique()

--- a/remo/profiles/templatetags/helpers.py
+++ b/remo/profiles/templatetags/helpers.py
@@ -37,7 +37,7 @@ def get_avatar_url(user, size=50):
     user_avatar, created = UserAvatar.objects.get_or_create(user=user)
     now = timezone.now()
 
-    if (user_avatar.last_update < now - timedelta(days=7)) or created:
+    if ((user_avatar.last_update < now - timedelta(days=7)) or created) and user.email:
         user_avatar.avatar_url = libravatar_url(email=user.email, https=True)
         user_avatar.save()
 

--- a/remo/profiles/views.py
+++ b/remo/profiles/views.py
@@ -30,9 +30,15 @@ from remo.voting.tasks import rotm_nomination_end_date
 USERNAME_ALGO = getattr(settings, 'OIDC_USERNAME_ALGO', default_username_algo)
 
 
+def check_user_status(user):
+    if user.is_superuser or user.groups.filter(name__in=['Rep', 'Admin']):
+        return True
+
+    return False
+
+
 @never_cache
-@user_passes_test(lambda u: u.groups.filter(Q(name='Rep') | Q(name='Admin')),
-                  login_url=settings.LOGIN_REDIRECT_URL)
+@user_passes_test(check_user_status, login_url=settings.LOGIN_REDIRECT_URL)
 @permission_check(permissions=['profiles.can_edit_profiles'],
                   filter_field='display_name', owner_field='user',
                   model=UserProfile)


### PR DESCRIPTION
So there were some issues that was raising the `SuspiciousOperation` exception. It was fixed in `mozilla-django-oidc==0.2.0`. But things need to be fixed before upgrading the version 0.2.0. Therefore override the `authenticate` method in `RemoAuthenticationBackend` backend and port the changes.

The `superuser` should have access to all page and should not necessarily complete full profile. Fix that issues so local development superuser dont fall into problem.

Moreover, fixing a issue where `display_name` become blank if any user create a user form management command without any email.

@akatsoulas @johngian r? 