### PR TITLE
Add 'Mobiliser Interest' and 'Mobiliser Skills' to user profile as we…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,13 @@ settings/local.py
 *.py[co]
 *.sw[po]
 .coverage
+.tox
 pip-log.txt
 docs/_gh-pages
 build.py
 build
 .DS_Store
+.vscode
 .noseids
 tmp/*
 *~

--- a/docs/installation-docker.rst
+++ b/docs/installation-docker.rst
@@ -49,6 +49,14 @@ When you want to start contributing...
 
     $ docker-compose run web ./manage.py loaddata demo_functional_areas
 
+#. Add demo mobilising skills::
+
+    $ docker-compose run web ./manage.py loaddata demo_mobilising_skills
+
+#. Add demo mobilising interests::
+
+    $ docker-compose run web ./manage.py loaddata demo_mobilising_interests
+
 #. Add demo events::
 
     $ docker-compose run web ./manage.py loaddata demo_events

--- a/docs/installation-virtualenv.rst
+++ b/docs/installation-virtualenv.rst
@@ -143,6 +143,14 @@ When you want to start contributing...
 
      (venv)$ ./manage.py loaddata demo_functional_areas
 
+   To load *demo mobilising skills* run::
+
+     (venv)$ ./manage.py loaddata demo_mobilising_skills
+
+   To load *demo mobilising interests* run::
+
+     (venv)$ ./manage.py loaddata demo_mobilising_interests
+
    To load *demo events* run::
 
      (venv)$ ./manage.py loaddata demo_events

--- a/remo/base/content_urls.py
+++ b/remo/base/content_urls.py
@@ -4,8 +4,8 @@ from django.core.urlresolvers import reverse_lazy
 from remo.base.views import BaseCreateView, BaseListView, BaseUpdateView
 from remo.events.models import EventMetric
 from remo.events.forms import EventMetricForm
-from remo.profiles.forms import FunctionalAreaForm
-from remo.profiles.models import FunctionalArea
+from remo.profiles.forms import FunctionalAreaForm, MobilisingSkillForm, MobilisingInterestForm
+from remo.profiles.models import FunctionalArea, MobilisingSkill, MobilisingInterest
 from remo.reports.forms import ActivityForm, CampaignForm
 from remo.reports.models import Activity, Campaign
 
@@ -61,6 +61,36 @@ urlpatterns = patterns(
             model=FunctionalArea, form_class=FunctionalAreaForm,
             success_url=reverse_lazy('list_functional_areas')),
         name='edit_functional_area'),
+    url('^mobilising_skills/$',
+        BaseListView.as_view(
+            model=MobilisingSkill,
+            create_object_url=reverse_lazy('create_mobilising_skills')),
+        name='list_mobilising_skills'),
+    url('^mobilising_skills/new/$',
+        BaseCreateView.as_view(
+            model=MobilisingSkill, form_class=MobilisingSkillForm,
+            success_url=reverse_lazy('list_mobilising_skills')),
+        name='create_mobilising_skills'),
+    url('^mobilising_skills/(?P<pk>\d+)/edit/$',
+        BaseUpdateView.as_view(
+            model=MobilisingSkill, form_class=MobilisingSkillForm,
+            success_url=reverse_lazy('list_mobilising_skills')),
+        name='edit_mobilising_skills'),
+    url('^mobilising_interests/$',
+        BaseListView.as_view(
+            model=MobilisingInterest,
+            create_object_url=reverse_lazy('create_mobilising_interests')),
+        name='list_mobilising_interests'),
+    url('^mobilising_interests/new/$',
+        BaseCreateView.as_view(
+            model=MobilisingInterest, form_class=MobilisingInterestForm,
+            success_url=reverse_lazy('list_mobilising_interests')),
+        name='create_mobilising_interests'),
+    url('^mobilising_interests/(?P<pk>\d+)/edit/$',
+        BaseUpdateView.as_view(
+            model=MobilisingSkill, form_class=MobilisingInterestForm,
+            success_url=reverse_lazy('list_mobilising_interests')),
+        name='edit_mobilising_interests'),
     url('^metrics/$',
         BaseListView.as_view(
             model=EventMetric,

--- a/remo/base/templates/settings.jinja
+++ b/remo/base/templates/settings.jinja
@@ -73,6 +73,16 @@ Mozilla Reps - Settings
                     <a href="{{ url('list_functional_areas') }}">Edit functional areas</a>
                   </p>
                 {% endif %}
+                {% if user_is_admin(user) %}
+                  <p>
+                    <a href="{{ url('list_mobilising_skills') }}">Edit mobilising skills</a>
+                  </p>
+                {% endif %}
+                {% if user_is_admin(user) %}
+                  <p>
+                    <a href="{{ url('list_mobilising_interests') }}">Edit mobilising interests</a>
+                  </p>
+                {% endif %}
                 <p>
                   <a href="{{ url('list_activities') }}">Edit activities</a>
                 </p>

--- a/remo/base/templates/settings.jinja
+++ b/remo/base/templates/settings.jinja
@@ -73,16 +73,12 @@ Mozilla Reps - Settings
                     <a href="{{ url('list_functional_areas') }}">Edit functional areas</a>
                   </p>
                 {% endif %}
-                {% if user_is_admin(user) %}
-                  <p>
-                    <a href="{{ url('list_mobilising_skills') }}">Edit mobilising skills</a>
-                  </p>
-                {% endif %}
-                {% if user_is_admin(user) %}
-                  <p>
-                    <a href="{{ url('list_mobilising_interests') }}">Edit mobilising interests</a>
-                  </p>
-                {% endif %}
+                <p>
+                  <a href="{{ url('list_mobilising_skills') }}">Edit mobilising skills</a>
+                </p>
+                <p>
+                  <a href="{{ url('list_mobilising_interests') }}">Edit mobilising interests</a>
+                </p>
                 <p>
                   <a href="{{ url('list_activities') }}">Edit activities</a>
                 </p>

--- a/remo/profiles/api/api_v1.py
+++ b/remo/profiles/api/api_v1.py
@@ -17,7 +17,7 @@ from tastypie.resources import ModelResource
 from remo.api import HttpCache, RemoAPIThrottle, RemoThrottleMixin
 from remo.base.serializers import CSVSerializer
 from remo.profiles.templatetags.helpers import get_avatar_url
-from remo.profiles.models import UserProfile, FunctionalArea
+from remo.profiles.models import UserProfile, FunctionalArea, MobilisingInterest, MobilisingSkill
 from remo.reports.models import NGReport
 from remo.reports.utils import get_last_report
 
@@ -38,6 +38,37 @@ class FunctionalAreasResource(RemoThrottleMixin, ModelResource):
         throttle = RemoAPIThrottle()
 
 
+class MobilisingSkillsResource(RemoThrottleMixin, ModelResource):
+    """Mobilising Skills Resource."""
+
+    class Meta:
+        queryset = MobilisingSkill.active_objects.all()
+        resource_name = 'mobilisingskills'
+        authentication = Authentication()
+        authorization = ReadOnlyAuthorization()
+        include_resource_uri = False
+        include_absolute_url = False
+        allowed_methods = ['get']
+        fields = ['name']
+        filtering = {'name': ALL}
+        throttle = RemoAPIThrottle()
+
+
+class MobilisingInterestsResource(RemoThrottleMixin, ModelResource):
+    """Mobilising Interests Resource."""
+
+    class Meta:
+        queryset = MobilisingInterest.active_objects.all()
+        resource_name = 'mobilisinginterests'
+        authentication = Authentication()
+        authorization = ReadOnlyAuthorization()
+        include_resource_uri = False
+        include_absolute_url = False
+        allowed_methods = ['get']
+        fields = ['name']
+        filtering = {'name': ALL}
+        throttle = RemoAPIThrottle()
+
 class ProfileResource(RemoThrottleMixin, ModelResource):
     """Profile Resource."""
     profile_url = fields.CharField()
@@ -46,6 +77,12 @@ class ProfileResource(RemoThrottleMixin, ModelResource):
     is_council = fields.BooleanField()
     functional_areas = fields.ToManyField(FunctionalAreasResource,
                                           attribute='functional_areas',
+                                          full=True, null=True)
+    mobilising_skills = fields.ToManyField(MobilisingSkillsResource,
+                                          attribute='mobilising_skills',
+                                          full=True, null=True)
+    mobilising_interests = fields.ToManyField(MobilisingInterestsResource,
+                                          attribute='mobilising_interests',
                                           full=True, null=True)
     mentor = fields.ToOneField('remo.profiles.api.api_v1.RepResource',
                                attribute='mentor', null=True)
@@ -70,7 +107,9 @@ class ProfileResource(RemoThrottleMixin, ModelResource):
                      'country': ALL,
                      'region': ALL,
                      'city': ALL,
-                     'functional_areas': ALL_WITH_RELATIONS}
+                     'functional_areas': ALL_WITH_RELATIONS,
+                     'mobilising_skills': ALL_WITH_RELATIONS,
+                     'mobilising_interests': ALL_WITH_RELATIONS}
         max_limit = 40
         throttle = RemoAPIThrottle()
 
@@ -80,6 +119,8 @@ class ProfileResource(RemoThrottleMixin, ModelResource):
             req = bundle.request.GET
             if req.get('format') == 'csv':
                 bundle.data.pop('functional_areas', None)
+                bundle.data.pop('mobilising_skills', None)
+                bundle.data.pop('mobilising_interests', None)
                 bundle.data.pop('personal_blog_feed', None)
                 bundle.data.pop('profile_url', None)
         return bundle
@@ -170,7 +211,9 @@ class RepResource(RemoThrottleMixin, ModelResource):
                      Q(userprofile__region__istartswith=query) |
                      Q(userprofile__city__istartswith=query) |
                      Q(userprofile__mozillians_profile_url__icontains=query) |
-                     Q(userprofile__functional_areas__name__istartswith=query))
+                     Q(userprofile__functional_areas__name__istartswith=query) |
+                     Q(userprofile__mobilising_skills__name__istartswith=query) |
+                     Q(userprofile__mobilising_interests__name__istartswith=query))
 
             base_object_list = base_object_list.filter(qset).distinct()
 

--- a/remo/profiles/api/serializers.py
+++ b/remo/profiles/api/serializers.py
@@ -4,7 +4,7 @@ from rest_framework import serializers
 
 from remo.api.serializers import BaseKPISerializer
 from remo.base.templatetags.helpers import absolutify
-from remo.profiles.models import FunctionalArea, UserProfile
+from remo.profiles.models import FunctionalArea, UserProfile, MobilisingInterest, MobilisingSkill
 
 
 class FunctionalAreaSerializer(serializers.ModelSerializer):
@@ -13,6 +13,24 @@ class FunctionalAreaSerializer(serializers.ModelSerializer):
     class Meta:
         model = FunctionalArea
         queryset = FunctionalArea.objects.filter(active=True)
+        fields = ['name']
+
+
+class MobilisingSkillSerializer(serializers.ModelSerializer):
+    """Serializer for the MobilisingSkill model."""
+
+    class Meta:
+        model = MobilisingSkill
+        queryset = MobilisingSkill.objects.filter(active=True)
+        fields = ['name']
+
+
+class MobilisingInterestSerializer(serializers.ModelSerializer):
+    """Serializer for the MobilisingInterest model."""
+
+    class Meta:
+        model = MobilisingInterest
+        queryset = MobilisingInterest.objects.filter(active=True)
         fields = ['name']
 
 
@@ -40,6 +58,8 @@ class UserProfileDetailedSerializer(serializers.HyperlinkedModelSerializer):
     mentor = UserSerializer()
     groups = GroupSerializer(source='user.groups', many=True)
     functional_areas = FunctionalAreaSerializer(many=True)
+    mobilising_skills = MobilisingSkillSerializer(many=True)
+    mobilising_interests = MobilisingInterestSerializer(many=True)
     remo_url = serializers.SerializerMethodField()
     date_joined_program = serializers.DateTimeField(format='%Y-%m-%d')
     date_left_program = serializers.DateTimeField(format='%Y-%m-%d')
@@ -51,9 +71,9 @@ class UserProfileDetailedSerializer(serializers.HyperlinkedModelSerializer):
                   'date_joined_program', 'date_left_program', 'city', 'region',
                   'country', 'twitter_account', 'jabber_id', 'irc_name',
                   'wiki_profile_url', 'irc_channels', 'linkedin_url',
-                  'facebook_url', 'diaspora_url', 'functional_areas', 'bio',
-                  'mentor', 'mozillians_profile_url', 'timezone', 'groups',
-                  'remo_url']
+                  'facebook_url', 'diaspora_url', 'functional_areas', 'mobilising_skills',
+                  'mobilising_interests', 'bio', 'mentor', 'mozillians_profile_url',
+                  'timezone', 'groups', 'remo_url']
 
     def get_remo_url(self, obj):
         """

--- a/remo/profiles/api/views.py
+++ b/remo/profiles/api/views.py
@@ -35,6 +35,10 @@ class UserProfileFilter(django_filters.FilterSet):
     groups = django_filters.CharFilter(name='groups__name')
     functional_areas = django_filters.CharFilter(
         name='userprofile__functional_areas__name')
+    mobilising_skills = django_filters.CharFilter(
+        name='userprofile__mobilising_skills__name')
+    mobilising_interests = django_filters.CharFilter(
+        name='userprofile__mobilising_interests__name')
     mentor = django_filters.CharFilter(name='userprofile__mentor')
     city = django_filters.CharFilter(name='userprofile__city')
     region = django_filters.CharFilter(name='userprofile__region')

--- a/remo/profiles/fixtures/demo_mobilising_interests.json
+++ b/remo/profiles/fixtures/demo_mobilising_interests.json
@@ -1,0 +1,20 @@
+[
+  {
+      "pk": 2,
+      "model": "profiles.mobilisinginterest",
+      "fields": {
+          "active": true,
+          "name": "WebVR",
+          "slug": "WebVR"
+      }
+  },
+  {
+      "pk": 3,
+      "model": "profiles.mobilisinginterest",
+      "fields": {
+          "active": true,
+          "name": "Rust",
+          "slug": "Rust"
+      }
+  }
+]

--- a/remo/profiles/fixtures/demo_mobilising_skills.json
+++ b/remo/profiles/fixtures/demo_mobilising_skills.json
@@ -1,0 +1,20 @@
+[
+  {
+      "pk": 2,
+      "model": "profiles.mobilisingskill",
+      "fields": {
+          "active": true,
+          "name": "WebVR",
+          "slug": "WebVR"
+      }
+  },
+  {
+      "pk": 3,
+      "model": "profiles.mobilisingskill",
+      "fields": {
+          "active": true,
+          "name": "Rust",
+          "slug": "Rust"
+      }
+  }
+]

--- a/remo/profiles/forms.py
+++ b/remo/profiles/forms.py
@@ -15,7 +15,7 @@ from pytz import common_timezones
 
 from remo.base.templatetags.helpers import user_is_rep
 from remo.base.utils import get_date
-from remo.profiles.models import FunctionalArea, UserProfile, UserStatus
+from remo.profiles.models import FunctionalArea, UserProfile, UserStatus, MobilisingInterest, MobilisingSkill
 
 
 USERNAME_ALGO = getattr(settings, 'OIDC_USERNAME_ALGO', default_username_algo)
@@ -159,7 +159,8 @@ class ChangeProfileForm(happyforms.ModelForm):
                   'irc_channels', 'facebook_url', 'linkedin_url',
                   'diaspora_url', 'personal_website_url', 'personal_blog_feed',
                   'bio', 'gender', 'mentor', 'wiki_profile_url',
-                  'functional_areas', 'timezone')
+                  'functional_areas', 'mobilising_skills', 'mobilising_interests',
+                  'timezone')
 
 
 class ChangeDatesForm(happyforms.ModelForm):
@@ -203,6 +204,20 @@ class FunctionalAreaForm(happyforms.ModelForm):
 
     class Meta:
         model = FunctionalArea
+        fields = ['name', 'active']
+
+class MobilisingSkillForm(happyforms.ModelForm):
+    """Form of mobilising skill."""
+
+    class Meta:
+        model = MobilisingSkill
+        fields = ['name', 'active']
+
+class MobilisingInterestForm(happyforms.ModelForm):
+    """Form of mobilising interest."""
+
+    class Meta:
+        model = MobilisingInterest
         fields = ['name', 'active']
 
 

--- a/remo/profiles/migrations/0006_auto_20171014_1300.py
+++ b/remo/profiles/migrations/0006_auto_20171014_1300.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('profiles', '0005_groups_new_resources_group'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='MobilisingInterest',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(unique=True, max_length=100)),
+                ('slug', models.SlugField(max_length=100, blank=True)),
+                ('active', models.BooleanField(default=True)),
+            ],
+            options={
+                'ordering': ['name'],
+                'verbose_name': 'mobilising skill',
+                'verbose_name_plural': 'mobilising skills',
+            },
+        ),
+        migrations.CreateModel(
+            name='MobilisingSkill',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(unique=True, max_length=100)),
+                ('slug', models.SlugField(max_length=100, blank=True)),
+                ('active', models.BooleanField(default=True)),
+            ],
+            options={
+                'ordering': ['name'],
+                'verbose_name': 'mobilising skill',
+                'verbose_name_plural': 'mobilising skills',
+            },
+        ),
+        migrations.AddField(
+            model_name='userprofile',
+            name='mobilising_interests',
+            field=models.ManyToManyField(related_name='users_matching', to='profiles.MobilisingInterest'),
+        ),
+        migrations.AddField(
+            model_name='userprofile',
+            name='mobilising_skills',
+            field=models.ManyToManyField(related_name='users_matching', to='profiles.MobilisingSkill'),
+        ),
+    ]

--- a/remo/profiles/models.py
+++ b/remo/profiles/models.py
@@ -94,6 +94,60 @@ class FunctionalArea(models.Model):
         verbose_name_plural = 'functional areas'
 
 
+@python_2_unicode_compatible
+class MobilisingSkill(models.Model):
+    """Mobilising skills."""
+    name = models.CharField(max_length=100, unique=True)
+    slug = models.SlugField(blank=True, max_length=100)
+    active = models.BooleanField(default=True)
+
+    objects = models.Manager()
+    active_objects = GenericActiveManager()
+
+    def save(self, *args, **kwargs):
+        # Create unique slug
+        if not self.slug:
+            self.slug = slugify(self.name, instance=self)
+        super(MobilisingSkill, self).save(*args, **kwargs)
+
+    def get_absolute_edit_url(self):
+        return reverse('edit_mobilising_skills', kwargs={'pk': self.id})
+
+    def __str__(self):
+        return self.name
+
+    class Meta:
+        ordering = ['name']
+        verbose_name = 'mobilising skill'
+        verbose_name_plural = 'mobilising skills'
+
+@python_2_unicode_compatible
+class MobilisingInterest(models.Model):
+    """Mobilising interests."""
+    name = models.CharField(max_length=100, unique=True)
+    slug = models.SlugField(blank=True, max_length=100)
+    active = models.BooleanField(default=True)
+
+    objects = models.Manager()
+    active_objects = GenericActiveManager()
+
+    def save(self, *args, **kwargs):
+        # Create unique slug
+        if not self.slug:
+            self.slug = slugify(self.name, instance=self)
+        super(MobilisingInterest, self).save(*args, **kwargs)
+
+    def get_absolute_edit_url(self):
+        return reverse('edit_mobilising_interests', kwargs={'pk': self.id})
+
+    def __str__(self):
+        return self.name
+
+    class Meta:
+        ordering = ['name']
+        verbose_name = 'mobilising skill'
+        verbose_name_plural = 'mobilising skills'
+
 class UserProfile(models.Model):
     """Definition of UserProfile Model."""
     user = models.OneToOneField(User)
@@ -159,6 +213,10 @@ class UserProfile(models.Model):
                                on_delete=models.SET_NULL)
     functional_areas = models.ManyToManyField(
         FunctionalArea, related_name='users_matching')
+    mobilising_skills = models.ManyToManyField(
+        MobilisingSkill, related_name='users_matching')
+    mobilising_interests = models.ManyToManyField(
+        MobilisingInterest, related_name='users_matching')
     tracked_functional_areas = models.ManyToManyField(
         FunctionalArea, related_name='users_tracking')
     receive_email_on_add_comment = models.BooleanField(null=False,

--- a/remo/profiles/static/profiles/js/profiles_people.js
+++ b/remo/profiles/static/profiles/js/profiles_people.js
@@ -10,6 +10,8 @@ ProfilesLib.noresults_elm = $('#profiles_noresults');
 ProfilesLib.adv_search_country_elm = $('#adv-search-country');
 ProfilesLib.adv_search_group_elm = $('#adv-search-group');
 ProfilesLib.adv_search_area_elm = $('#adv-search-area');
+ProfilesLib.adv_search_skill_elm = $('#adv-search-skill');
+ProfilesLib.adv_search_interest_elm = $('#adv-search-interest');
 ProfilesLib.search_ready_icon_elm = $('#search-ready-icon');
 ProfilesLib.search_loading_icon_elm = $('#search-loading-icon');
 ProfilesLib.grid_search_list_elm = $('#grid-search-list');
@@ -219,6 +221,18 @@ function send_query(newquery) {
         extra_q += '&profile__functional_areas__name__iexact=' + area;
     }
 
+    var skill = hash_get_value('skill');
+    set_dropdown_value(ProfilesLib.adv_search_skill_elm, skill);
+    if (skill) {
+        extra_q += '&profile__mobilising_skills__name__iexact=' + skill;
+    }
+
+    var interest = hash_get_value('interest');
+    set_dropdown_value(ProfilesLib.adv_search_interest_elm, interest);
+    if (interest) {
+        extra_q += '&profile__mobilising_interests__name__iexact=' + interest;
+    }
+
     var search = hash_get_value('search');
     ProfilesLib.searchfield_elm.val(search);
     if (search) {
@@ -306,6 +320,14 @@ function bind_events() {
         hash_set_value('area', ProfilesLib.adv_search_area_elm.val());
     });
 
+    ProfilesLib.adv_search_skill_elm.change(function() {
+        hash_set_value('skill', ProfilesLib.adv_search_skill_elm.val());
+    });
+
+    ProfilesLib.adv_search_interest_elm.change(function() {
+        hash_set_value('interest', ProfilesLib.adv_search_interest_elm.val());
+    });
+
     ProfilesLib.window_elm.bind('hashchange', function(e) {
         // Set icon.
         ProfilesLib.search_ready_icon_elm.hide();
@@ -324,6 +346,8 @@ function unbind_events() {
     ProfilesLib.adv_search_country_elm.unbind('change');
     ProfilesLib.adv_search_group_elm.unbind('change');
     ProfilesLib.adv_search_area_elm.unbind('change');
+    ProfilesLib.adv_search_skill_elm.unbind('change');
+    ProfilesLib.adv_search_interest_elm.unbind('change');
     ProfilesLib.window_elm.unbind('hashchange');
 }
 
@@ -407,6 +431,8 @@ $(document).ready(function () {
     // Set values to fields.
     set_dropdown_value(ProfilesLib.adv_search_group_elm, hash_get_value('group'));
     set_dropdown_value(ProfilesLib.adv_search_area_elm, hash_get_value('area'));
+    set_dropdown_value(ProfilesLib.adv_search_skill_elm, hash_get_value('skill'));
+    set_dropdown_value(ProfilesLib.adv_search_interest_elm, hash_get_value('interest'));
     set_dropdown_value(ProfilesLib.adv_search_country_elm, hash_get_value('country'));
 
     // Bind events.

--- a/remo/profiles/templates/profiles_edit.jinja
+++ b/remo/profiles/templates/profiles_edit.jinja
@@ -488,6 +488,42 @@
             <div class="required-field"></div>
           </div>
         </div>
+        <div class="row">
+          <div class="large-1 columns">
+            <div class="pict-icon large tools"></div>
+          </div>
+          <div class="large-11 columns edit-profile-item" id="skills">
+            <div>
+                <button class="small white button nice radius"
+                        data-reveal-id="mobilising-skills-modal"
+                        id="skills-button">Mark your mobilising skills</button>
+                {% if profileform.mobilising_skills.errors %}
+                  <small class="error">
+                    Please mark your mobilising skills
+                  </small>
+                {% endif %}
+            </div>
+            <div class="required-field"></div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="large-1 columns">
+            <div class="pict-icon large heart"></div>
+          </div>
+          <div class="large-11 columns edit-profile-item" id="mobilising-interest">
+            <div>
+                <button class="small white button nice radius"
+                        data-reveal-id="mobilising-interests-modal"
+                        id="interest-button">Mark your mobilising interests</button>
+                {% if profileform.mobilising_interests.errors %}
+                  <small class="error">
+                    Please mark your mobilising interests
+                  </small>
+                {% endif %}
+            </div>
+            <div class="required-field"></div>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -623,6 +659,60 @@
       </ul>
       <a href="#" class="button small update close-reveal-modal">
         Choose these areas &raquo;
+      </a>
+    </div>
+
+    <!-- Mobilising skills modal -->
+    <div id="mobilising-skills-modal" class="reveal-modal medium">
+      <a class="close-reveal-modal">&#215;</a>
+      <p class="lead">
+        Specify your skills in Mobilising
+      </p>
+      <h3>
+        Mobilising Skills
+      </h3>
+      <ul class="large-block-grid-3 small-block-grid-1">
+        {% for choice in profileform.mobilising_skills.field.choices %}
+          <li>
+            <label for="{{ choice.1|replace(" ","-") }}-bit">
+              <input type="checkbox" name="mobilising_skills" value="{{ choice.0 }}"
+                     id="{{ choice.1|replace(" ","-") }}-bit"
+                     {% if choice.0 in mobilising_skills %}
+                       checked="checked"
+                     {% endif %}/>
+              {{ choice.1 }}
+          </li>
+        {% endfor %}
+      </ul>
+      <a href="#" class="button small update close-reveal-modal">
+        Choose these skills &raquo;
+      </a>
+    </div>
+
+    <!-- Mobilising interests modal -->
+    <div id="mobilising-interests-modal" class="reveal-modal medium">
+      <a class="close-reveal-modal">&#215;</a>
+      <p class="lead">
+        Specify your interests in Mobilising
+      </p>
+      <h3>
+        Mobilising Interests
+      </h3>
+      <ul class="large-block-grid-3 small-block-grid-1">
+        {% for choice in profileform.mobilising_interests.field.choices %}
+          <li>
+            <label for="{{ choice.1|replace(" ","-") }}-bit">
+              <input type="checkbox" name="mobilising_interests" value="{{ choice.0 }}"
+                     id="{{ choice.1|replace(" ","-") }}-bit"
+                     {% if choice.0 in mobilising_interests %}
+                       checked="checked"
+                     {% endif %}/>
+              {{ choice.1 }}
+          </li>
+        {% endfor %}
+      </ul>
+      <a href="#" class="button small update close-reveal-modal">
+        Choose these interests &raquo;
       </a>
     </div>
   </form>

--- a/remo/profiles/templates/profiles_people.jinja
+++ b/remo/profiles/templates/profiles_people.jinja
@@ -71,6 +71,22 @@
             {% endfor %}
           </select>
         </div>
+        <div class="large-3 columns">
+          <select id="adv-search-skill">
+            <option value="">All Mobiliser Skills</option>
+            {% for skill in skills %}
+              <option value="{{ skill|lower }}">{{ skill }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="large-3 columns">
+          <select id="adv-search-interest">
+            <option value="">All Mobiliser Interests</option>
+            {% for interest in interests %}
+              <option value="{{ interest|lower }}">{{ interest }}</option>
+            {% endfor %}
+          </select>
+        </div>
         <div class="large-3 columns align-center">
           {% if user.is_authenticated() %}
             <button id="csv-export-button"

--- a/remo/profiles/templates/profiles_view.jinja
+++ b/remo/profiles/templates/profiles_view.jinja
@@ -488,6 +488,44 @@ Mozilla Reps - Profile of {{ user_profile.display_name }}
           </div>
         </div>
       {% endif %}
+      {% if user_profile.mobilising_skills.all() %}
+        <div class="row profile-detail-list">
+          <div class="large-1 columns pictogram">
+            <div class="pict-icon large tools"></div>
+          </div>
+          <div class="large-11 columns">
+            <p class="profile-item">
+              <span class="label radius">
+                Mobilising Skills
+              </span>
+              &nbsp;
+              {% for skill in user_profile.mobilising_skills.all() %}
+                <a href="{{ url('profiles_list_profiles') }}skills/{{ skill.name }}/">
+                   {{ skill.name }}</a>{% if not loop.last %}, {% endif %}
+              {% endfor %}
+            </p>
+          </div>
+        </div>
+      {% endif %}
+      {% if user_profile.mobilising_interests.all() %}
+        <div class="row profile-detail-list">
+          <div class="large-1 columns pictogram">
+            <div class="pict-icon large heart"></div>
+          </div>
+          <div class="large-11 columns">
+            <p class="profile-item">
+              <span class="label radius">
+                Mobilising Interests
+              </span>
+              &nbsp;
+              {% for interest in user_profile.mobilising_interests.all() %}
+                <a href="{{ url('profiles_list_profiles') }}interest/{{ interest.name }}/">
+                   {{ interest.name }}</a>{% if not loop.last %}, {% endif %}
+              {% endfor %}
+            </p>
+          </div>
+        </div>
+      {% endif %}
       {% if perms.profiles.can_edit_profiles %}
         {% if added_by %}
           <div class="row profile-detail-list">

--- a/remo/profiles/templatetags/helpers.py
+++ b/remo/profiles/templatetags/helpers.py
@@ -56,21 +56,6 @@ def get_functional_area(name):
     except FunctionalArea.DoesNotExist:
         return None
 
-@library.filter
-def get_mobilising_skill(name):
-    """Return the Mobilising Skills object given the name."""
-    try:
-        return MobilisingSkill.objects.get(name=name)
-    except MobilisingSkill.DoesNotExist:
-        return None
-
-@library.filter
-def get_mobilising_interest(name):
-    """Return the Mobilising Interest object given the name."""
-    try:
-        return MobilisingInterest.objects.get(name=name)
-    except MobilisingInterest.DoesNotExist:
-        return None
 
 @library.filter
 def get_activity_level(user):

--- a/remo/profiles/templatetags/helpers.py
+++ b/remo/profiles/templatetags/helpers.py
@@ -56,6 +56,21 @@ def get_functional_area(name):
     except FunctionalArea.DoesNotExist:
         return None
 
+@library.filter
+def get_mobilising_skill(name):
+    """Return the Mobilising Skills object given the name."""
+    try:
+        return MobilisingSkill.objects.get(name=name)
+    except MobilisingSkill.DoesNotExist:
+        return None
+
+@library.filter
+def get_mobilising_interest(name):
+    """Return the Mobilising Interest object given the name."""
+    try:
+        return MobilisingInterest.objects.get(name=name)
+    except MobilisingInterest.DoesNotExist:
+        return None
 
 @library.filter
 def get_activity_level(user):

--- a/remo/profiles/views.py
+++ b/remo/profiles/views.py
@@ -24,7 +24,7 @@ from remo.base.decorators import permission_check
 from remo.base.templatetags.helpers import urlparams
 from remo.events.utils import get_events_for_user
 from remo.profiles.models import UserProfile, UserStatus
-from remo.profiles.models import FunctionalArea
+from remo.profiles.models import FunctionalArea, MobilisingInterest, MobilisingSkill
 from remo.voting.tasks import rotm_nomination_end_date
 
 USERNAME_ALGO = getattr(settings, 'OIDC_USERNAME_ALGO', default_username_algo)
@@ -119,6 +119,8 @@ def edit(request, display_name):
                       'Resources'])
 
     functional_areas = map(int, profileform['functional_areas'].value())
+    mobilising_skills = map(int, profileform['mobilising_skills'].value())
+    mobilising_interests = map(int, profileform['mobilising_interests'].value())
     user_is_alumni = user.groups.filter(name='Alumni').exists()
 
     return render(request, 'profiles_edit.jinja',
@@ -129,6 +131,8 @@ def edit(request, display_name):
                    'group_bits': group_bits,
                    'range_years': range(1950, now().date().year - 11),
                    'functional_areas': functional_areas,
+                   'mobilising_skills': mobilising_skills,
+                   'mobilising_interests': mobilising_interests,
                    'user_is_alumni': user_is_alumni})
 
 
@@ -152,7 +156,9 @@ def list_profiles(request):
     return render(request, 'profiles_people.jinja',
                   {'countries': countries,
                    'reps': reps,
-                   'areas': FunctionalArea.objects.all()})
+                   'areas': FunctionalArea.objects.all(),
+                   'skills': MobilisingSkill.objects.all(),
+                   'interests': MobilisingInterest.objects.all()})
 
 
 @cache_control(private=True, max_age=60 * 5)


### PR DESCRIPTION
…ll as make it possible to define them in the admin area and search for them in the search

* Add 'Mobiliser Interest' field to profile
* Add 'Mobiliser Skill' field to profile
* Make it possible to search for those two new fields in the search
* Make it possible to edit those as admin in the portal settings
* Added fixtures for the new tables
* Added migrations

General notes:
* No tests written yet, need to figure out how that works in this project :)
* New fields not added to reporting component (and some other components), we don't need that for now, will add once we need it (MVP for now)
* FunctionalArea, MobilisingSkill, MobilisingInterest could probably be generalized, but I don't know Python well enough yet to do this, as it would still require seperate tables etc