### PR TITLE
WIP: Bug 1070716 - Only allow Admin/Council to change mentor

### DIFF
--- a/remo/profiles/apps.py
+++ b/remo/profiles/apps.py
@@ -11,8 +11,9 @@ def profiles_set_groups(sender, **kwargs):
         return True
 
     perms = {'create_user': ['Admin', 'Mentor'],
-             'can_edit_profiles': ['Admin'],
-             'can_delete_profiles': ['Admin']}
+             'can_edit_profiles': ['Admin', 'Council'],
+             'can_delete_profiles': ['Admin'],
+             'can_change_mentor': ['Admin', 'Council']}
 
     add_permissions_to_groups('profiles', perms)
 

--- a/remo/profiles/forms.py
+++ b/remo/profiles/forms.py
@@ -137,19 +137,6 @@ class ChangeProfileForm(happyforms.ModelForm):
         twitter_account = self.cleaned_data['twitter_account']
         return twitter_account.strip('@')
 
-    def clean(self):
-        """Override clean method for custom functionality."""
-        mentor = self.cleaned_data.get('mentor')
-
-        # Do not raise a validation error if the user belongs to the Alumni
-        # group or has admin privileges
-        if (not mentor and not
-                self.request.user.groups.filter(name='Admin').exists()):
-            msg = u'This field is required'
-            self.errors['mentor'] = self.error_class([msg])
-
-        return self.cleaned_data
-
     class Meta:
         model = UserProfile
         fields = ('local_name', 'birth_date',

--- a/remo/profiles/migrations/0010_auto_20171221_0112.py
+++ b/remo/profiles/migrations/0010_auto_20171221_0112.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('profiles', '0009_auto_20171101_2202'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='userprofile',
+            options={'permissions': (('create_user', 'Can create new user'), ('can_edit_profiles', 'Can edit profiles'), ('can_delete_profiles', 'Can delete profiles'), ('can_change_mentor', 'Can change mentors'))},
+        ),
+    ]

--- a/remo/profiles/models.py
+++ b/remo/profiles/models.py
@@ -253,7 +253,8 @@ class UserProfile(models.Model):
     class Meta:
         permissions = (('create_user', 'Can create new user'),
                        ('can_edit_profiles', 'Can edit profiles'),
-                       ('can_delete_profiles', 'Can delete profiles'))
+                       ('can_delete_profiles', 'Can delete profiles'),
+                       ('can_change_mentor', 'Can change mentors'))
 
     def get_absolute_url(self):
         return reverse('remo.profiles.views.view_profile',

--- a/remo/profiles/templates/profiles_edit.jinja
+++ b/remo/profiles/templates/profiles_edit.jinja
@@ -202,14 +202,16 @@
                 {{ profileform.wiki_profile_url.errors }}
               </small>
             {% endif %}
-            <div class="has-tip tip-left" title="Mentor" data-tooltip data-options="disable-for-touch:true">
-              {{ profileform.mentor }}
-            </div>
-            <div class="required-field"></div>
-            {% if profileform.mentor.errors %}
-              <small class="error">
-                {{ profileform.mentor.errors }}
-              </small>
+            {% if perms.profiles.can_change_mentor %}
+              <div class="has-tip tip-left" title="Mentor" data-tooltip data-options="disable-for-touch:true">
+                {{ profileform.mentor }}
+              </div>
+              <div class="required-field"></div>
+              {% if profileform.mentor.errors %}
+                <small class="error">
+                  {{ profileform.mentor.errors }}
+                </small>
+              {% endif %}
             {% endif %}
           </div>
         </div>

--- a/remo/profiles/tests/test_models.py
+++ b/remo/profiles/tests/test_models.py
@@ -281,7 +281,8 @@ class PermissionTest(RemoTestCase):
         """Setup tests."""
         self.permissions = [
             'profiles.create_user',
-            'profiles.can_edit_profiles']
+            'profiles.can_edit_profiles',
+            'profiles.can_change_mentor']
 
     def test_admin_group_has_all_permissions(self):
         """Test that admin group has all permissions."""
@@ -289,11 +290,10 @@ class PermissionTest(RemoTestCase):
         for permission in self.permissions:
             ok_(admin.has_perm(permission))
 
-    def test_council_group_has_no_permissions(self):
-        """Test that council group has no permissions."""
+    def test_council_group_has_mentor_change_permissions(self):
+        """Test that council group has mentor change permissions."""
         councelor = UserFactory.create(groups=['Council'])
-        for permission in self.permissions:
-            ok_(not councelor.has_perm(permission))
+        ok_(councelor.has_perm('profiles.can_edit_profiles'))
 
     def test_mentor_group_has_one_permission(self):
         """Test that mentor group has only create_user permission."""


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1070716
This is a work in progress.

The tests pass, however it doesn't work when I test this with a Council account. The field doesn't show up since the perm doesn't get applied to the council member. How can I make sure that existing users get that permission as well?

@akatsoulas not important right now, let's focus on the other PRs for now. However, once you have time, would love to learn more about this :)