### PR TITLE
[fix bug 1245643] Erroneous mail content when a comment is written on…

### DIFF
--- a/remo/events/models.py
+++ b/remo/events/models.py
@@ -282,7 +282,7 @@ def email_event_owner_on_add_comment(sender, instance, **kwargs):
     owner = instance.event.owner
     event_url = reverse('events_view_event', kwargs={'slug': event.slug})
     ctx_data = {'event': event, 'owner': owner, 'user': instance.user,
-                'comment': instance.comment, 'event_url': event_url}
+                'comment': instance.comment, 'event_url': event_url, 'commenter': instance.user}
     if owner.userprofile.receive_email_on_add_event_comment:
         subject = subject % (instance.user.get_full_name(), instance.event.name)
         send_remo_mail.delay(subject=subject, recipients_list=[owner.id],

--- a/remo/events/models.py
+++ b/remo/events/models.py
@@ -281,8 +281,8 @@ def email_event_owner_on_add_comment(sender, instance, **kwargs):
     event = instance.event
     owner = instance.event.owner
     event_url = reverse('events_view_event', kwargs={'slug': event.slug})
-    ctx_data = {'event': event, 'owner': owner, 'user': instance.user,
-                'comment': instance.comment, 'event_url': event_url, 'commenter': instance.user}
+    ctx_data = {'event': event, 'owner': owner, 'commenter': instance.user,
+                'comment': instance.comment, 'event_url': event_url}
     if owner.userprofile.receive_email_on_add_event_comment:
         subject = subject % (instance.user.get_full_name(), instance.event.name)
         send_remo_mail.delay(subject=subject, recipients_list=[owner.id],

--- a/remo/events/templates/email/owner_notification_on_add_comment.jinja
+++ b/remo/events/templates/email/owner_notification_on_add_comment.jinja
@@ -1,6 +1,6 @@
 Hey there {{ owner.first_name|capitalize }},
 
-This email was generated automatically to inform you that {{ user.get_full_name() }}
+This email was generated automatically to inform you that {{ commenter.get_full_name() }}
 added a comment on the event you are organizing [1].
 
 The comment was:


### PR DESCRIPTION
Email templete user object is overwitten by recipient user object. Have changed the name of the object in email template and passed value for that object also which fixes this issue 