### PR TITLE
Bug 1436892 / Bug 1436891 - Enable sections on dashboard for specific groups

### DIFF
--- a/remo/dashboard/templates/dashboard_reps.jinja
+++ b/remo/dashboard/templates/dashboard_reps.jinja
@@ -1052,8 +1052,8 @@
 {% endif %}
 <!-- end planning requests block -->
 
-<!-- Admin block -->
-{% if is_admin is defined %}
+<!-- Strategy block -->
+{% if can_view_administration %}
   <div class="row">
     <div class="large-7 columns dashboard-box">
       <h2>Administration</h2>
@@ -1156,7 +1156,6 @@
     </div>
     {% endif %}
   </div>
-  <!-- End Admin block -->
 {% endif %}
 {% endblock %}
 

--- a/remo/dashboard/views.py
+++ b/remo/dashboard/views.py
@@ -130,9 +130,18 @@ def dashboard(request):
     my_mentees = User.objects.filter(userprofile__mentor=user,
                                      userprofile__registration_complete=True,
                                      groups__name='Rep')
+    reps = User.objects.filter(groups__name='Rep')
 
     args['my_budget_requests'] = budget_requests.filter(my_q).distinct()
     args['my_swag_requests'] = swag_requests.filter(my_q).distinct()
+
+    if user.groups.filter(
+        Q(name='Admin') |
+        Q(name='Council') |
+        Q(name='Peers') |
+        Q(name='Onboarding')
+    ).exists():
+        args['can_view_administration'] = True
 
     if user.groups.filter(name='Mentor').exists():
         args['mentees_action_items'] = ActionItem.objects.filter(user__in=my_mentees,
@@ -157,12 +166,12 @@ def dashboard(request):
     else:
         args['my_planning_requests'] = planning_requests.filter(my_q_assigned).distinct()
 
-    if user.groups.filter(name='Admin').exists():
-        args['is_admin'] = True
-        reps = User.objects.filter(groups__name='Rep')
+    if user.groups.filter(Q(name='Admin') | Q(name='Council') | Q(name='Onboarding')).exists():
+        args['reps_without_profile'] = reps.filter(userprofile__registration_complete=False)
+
+    if user.groups.filter(Q(name='Admin') | Q(name='Council') | Q(name='Peers')).exists():
         args['reps_without_mentors'] = reps.filter(
             userprofile__registration_complete=True, userprofile__mentor=None)
-        args['reps_without_profile'] = reps.filter(userprofile__registration_complete=False)
 
     statsd.incr('dashboard.dashboard_reps')
     return render(request, 'dashboard_reps.jinja', args)


### PR DESCRIPTION
* Enables "Reps without Mentors" section for Council and Peers members - previously Admin only
* Enables "Reps without profile" section for Council and Onboarding members - previously Admin only