### PR TITLE
fix(user_fixture): Fix conflict to correctly load fixtures

### DIFF
--- a/remo/profiles/fixtures/demo_users.json
+++ b/remo/profiles/fixtures/demo_users.json
@@ -3,7 +3,7 @@
         "pk": 4,
         "model": "auth.user",
         "fields": {
-            "username": "admin",
+            "username": "nikos-admin",
             "first_name": "Nikos",
             "last_name": "Koukos",
             "is_active": true,
@@ -167,7 +167,7 @@
         "fields": {
             "city": "Athens",
             "twitter_account": "",
-            "display_name": "admin",
+            "display_name": "admin-1",
             "private_email": "admin@example.com",
             "local_name": "Lalala Lololo",
             "region":"attika",

--- a/remo/profiles/fixtures/demo_users.json
+++ b/remo/profiles/fixtures/demo_users.json
@@ -3,7 +3,7 @@
         "pk": 4,
         "model": "auth.user",
         "fields": {
-            "username": "nikos-admin",
+            "username": "admin",
             "first_name": "Nikos",
             "last_name": "Koukos",
             "is_active": true,


### PR DESCRIPTION
User fixtures weren't loading due to conflict in username. Because of this, the event data was also prevented from loading.

Just fixed this issue so that future contributors don't have this problem.

cc @MichaelKohler 